### PR TITLE
Implement --json flag for changing report types

### DIFF
--- a/gator/arguments.py
+++ b/gator/arguments.py
@@ -19,6 +19,12 @@ def parse(args):
         "--nowelcome", help="do not display the welcome message", action="store_true"
     )
 
+    # output reports in JSON
+    # CORRECT WHEN: always, only changes report output
+    gg_parser.add_argument(
+        "--json", help="print reports in JSON", action="store_true"
+    )
+
     # Top-Level Arguments {{{
 
     # specify a check for the number of commits in the Git repository

--- a/gator/orchestrate.py
+++ b/gator/orchestrate.py
@@ -39,6 +39,10 @@ def check_arguments(system_arguments):
     # Action: display the welcome message
     if gg_arguments.nowelcome is not True:
         actions.append([DISPLAY, "welcome_message", VOID])
+    if gg_arguments.json is True:
+        # pylint: disable=global-statement
+        global OUTPUT_TYPE
+        OUTPUT_TYPE = getattr(REPORT, "JSON")
     did_verify_arguments = arguments.verify(gg_arguments)
     # arguments are incorrect
     if did_verify_arguments is False:

--- a/gator/orchestrate.py
+++ b/gator/orchestrate.py
@@ -26,7 +26,9 @@ SINGLE = "single-line"
 MULTIPLE = "multiple-line"
 REPOSITORY = "."
 
-OUTPUT_TYPE = getattr(REPORT, "TEXT")
+JSON = "JSON"
+TEXT = "TEXT"
+OUTPUT_TYPE = getattr(REPORT, TEXT)
 
 NOTHING = ""
 
@@ -42,7 +44,7 @@ def check_arguments(system_arguments):
     if gg_arguments.json is True:
         # pylint: disable=global-statement
         global OUTPUT_TYPE
-        OUTPUT_TYPE = getattr(REPORT, "JSON")
+        OUTPUT_TYPE = getattr(REPORT, JSON)
     did_verify_arguments = arguments.verify(gg_arguments)
     # arguments are incorrect
     if did_verify_arguments is False:

--- a/gator/orchestrate.py
+++ b/gator/orchestrate.py
@@ -16,6 +16,7 @@ ORCHESTRATE = sys.modules[__name__]
 DISPLAY = sys.modules["gator.display"]
 INVOKE = sys.modules["gator.invoke"]
 RUN = sys.modules["gator.run"]
+REPORT = sys.modules["gator.report"]
 
 VOID = []
 
@@ -24,6 +25,8 @@ INCORRECT_ARGUMENTS = 2
 SINGLE = "single-line"
 MULTIPLE = "multiple-line"
 REPOSITORY = "."
+
+OUTPUT_TYPE = getattr(REPORT, "TEXT")
 
 NOTHING = ""
 
@@ -277,7 +280,7 @@ def check(system_arguments):
         check_results.extend(step_results)
     # Section: Output the report
     # Only step: get the report's details, produce the output, and display it
-    output_list = report.output_list(report.get_details(), report.TEXT)
+    output_list = report.output_list(report.get_details(), OUTPUT_TYPE)
     produced_output = report.output(output_list)
     display.message(produced_output)
     # Section: Return control back to __main__ in gatorgrader

--- a/gator/report.py
+++ b/gator/report.py
@@ -136,4 +136,5 @@ def output_text(dictionary_result, output_collector):
 
 def output_json(dictionary_result, output_collector):
     """Produce output in a JSON-based textual format"""
-    output_collector.append(json.dumps(dictionary_result))
+    for result in dictionary_result.values():
+        output_collector.append(json.dumps(result))

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -273,7 +273,6 @@ def test_perform_actions_display_welcome_and_ready_check_count_command_json(
     chosen_arguments = ["--nowelcome", "--command", "ls", "--count", "2", "--json"]
     exit_code = orchestrate.check(chosen_arguments)
     captured = capsys.readouterr()
-    print("*" + captured.out + "*")
     counted_newlines = captured.out.count("\n")
     assert "GatorGrader" not in captured.out
     assert counted_newlines == 2

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -262,3 +262,19 @@ def test_perform_actions_display_welcome_and_ready_check_count_command(
     assert "GatorGrader" in captured.out
     assert counted_newlines == 6
     assert exit_code == 0
+
+
+# pylint: disable=redefined-outer-name
+# pylint: disable=bad-continuation
+def test_perform_actions_display_welcome_and_ready_check_count_command_json(
+    capsys, reset_results_dictionary
+):
+    """Check the argument verification, messages, and continue for JSON output"""
+    chosen_arguments = ["--nowelcome", "--command", "ls", "--count", "2", "--json"]
+    exit_code = orchestrate.check(chosen_arguments)
+    captured = capsys.readouterr()
+    print("*" + captured.out + "*")
+    counted_newlines = captured.out.count("\n")
+    assert "GatorGrader" not in captured.out
+    assert counted_newlines == 2
+    assert exit_code == 0

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -196,7 +196,7 @@ def test_output_json(reset_results_dictionary):
     report.add_result("Check for 3 paragraphs", False, "Only found 2 paragraphs")
     report.add_result("Check for 10 comments", False, "Only found 2 comments")
     output_list = report.output_list(report.get_details(), report.JSON)
-    assert len(output_list) == 1
+    assert len(output_list) == 3
     output = " ".join(output_list)
     assert output is not None
     assert "\n" not in output
@@ -210,7 +210,7 @@ def test_output_json_complete(reset_results_dictionary):
     report.add_result("Check for 3 paragraphs", False, "Only found 2 paragraphs")
     report.add_result("Check for 10 comments", False, "Only found 2 comments")
     output_list = report.output_list(report.get_details(), report.JSON)
-    assert len(output_list) == 1
+    assert len(output_list) == 3
     output = " ".join(output_list)
     produced_output = report.output(output_list)
     assert output is produced_output

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -213,4 +213,4 @@ def test_output_json_complete(reset_results_dictionary):
     assert len(output_list) == 3
     output = " ".join(output_list)
     produced_output = report.output(output_list)
-    assert output is produced_output
+    assert output == produced_output


### PR DESCRIPTION
This implements the `--json` flag that will switch the report type to JSON. The old implementation of `output_json` (already written by @gkapfham) provides both the index of the check, and the check results themselves. The new implementation simply adds each of the check result 'objects' to a list which is then printed, resulting in the following format (whitespace is not guarenteed):

```
{
  "check": "Description of check",
  "outcome": true,
  "diagnostic": ""
}

{
  "check": "Another check",
  "outcome": false,
  "diagnostic": "Description of failure"
}
```