### PR TITLE
Format every code file with black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - pipenv run flake8 gatorgrader*
   - pipenv run pylint tests
   - pipenv run pylint gator
+  - pipenv run black gator/* tests/* --check
   - mdl README.md
 
 # report coverage information to CodeCov

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -17,6 +17,8 @@ def test_run_broken_command_returns_nonzero():
     assert output == b""
     assert error != b""
     assert code != 0
+
+
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
 
@@ -36,7 +38,7 @@ def test_run_command_grab_output_as_string(tmpdir):
 
 def test_run_invalid_output():
     """Checks that invalid unicode bytestrings are handled correctly"""
-    invalid_byte_sequence = b'\x80\x81'
+    invalid_byte_sequence = b"\x80\x81"
     output = run.get_actual_output(invalid_byte_sequence)
     assert invalid_byte_sequence in output
 


### PR DESCRIPTION
It seems that `test_run.py` was not fully formatted with `black`. This PR also adds `pipenv run black gator/* tests/* --check` to `.travis.yml` to ensure that this issue does not happen again in the future -- it will be picked up by Travis CI in any branch.