### PR TITLE
Revert "Implement a Markdown AST Parser"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 gitpython = "*"
 requests = ">=2.20.0"
-commonmark = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "16e9a8d92bcfb53dce8b81d1857049ce1620c08ca57b03c35b1f3e6484d0ea17"
+            "sha256": "2243de424d57eb62719bd0013f81833a16fb4a6757011762b90c6c7387cdd38a"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -27,20 +27,6 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
-        },
-        "commonmark": {
-            "hashes": [
-                "sha256:9f6dda7876b2bb88dd784440166f4bc8e56cb2b2551264051123bacb0b6c1d8a",
-                "sha256:abcbc854e0eae5deaf52ae5e328501b78b4a0758bf98ac8bb792fce993006084"
-            ],
-            "index": "pypi",
-            "version": "==0.8.1"
-        },
-        "future": {
-            "hashes": [
-                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
-            ],
-            "version": "==0.17.1"
         },
         "gitdb2": {
             "hashes": [

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -15,21 +15,24 @@ from gator import fragments
         ("hello world!!%^(@after)writing a lot\n", 1),
         ("hello world!!%^(@after)writing a lot\n\n", 1),
         ("", 0),
+        ("", 0),
+        (" ", 0),
         (" ", 0),
         ("     ", 0),
+        ("     ", 0),
+        ("a     ", 1),
         ("a     ", 1),
         ("a\n     ", 1),
-        # headers
         ("# Section Header", 0),
         ("# Section Header\n\nNot Section Header", 1),
         ("Paragraph\n\n\n# Section Header", 1),
-        # lists
-        ("Paragraph1\n - first item\n - second item", 1),
-        (" - first item\n - second item\n", 0),
-        # code blocks
         ("Paragraph\n\n```\nShould not be a paragraph\n```", 1),
         ("```\nShould not be\na paragraph\n```", 0),
-        ("Paragraph `inline code block` and end", 1),
+        (
+            "Beginning of paragraph ``` Still in fences but now \
+    also in paragraph ``` and end",
+            1,
+        ),
     ],
 )
 def test_paragraphs_zero_or_one(writing_string, expected_count):
@@ -45,15 +48,7 @@ def test_paragraphs_zero_or_one(writing_string, expected_count):
         ("hello world\n\nhi\n\nff!$@name", 3),
         ("hello world\n\nhi\n\nff!$@name\n\n^^44", 4),
         ("hello world 44\n\nhi\n\nff!$@name\n\n^^44", 4),
-        # headers
         ("# Section Header\n\nhello world 44\n\nhi\n\nff!$@name\n\n^^44", 4),
-        # lists
-        ("Paragraph1\n 1. item one\n 2. item two\n\nParagraph2", 2),
-        # Thematic, line and soft breaks
-        ("** ***", 0),
-        ("This is one paragraph.\n___\nThis is another paragraph.", 2),
-        ("Line break.  \nHello\\\nLine break.", 1),
-        ("This is a soft break\n\nThis is the second paragraph", 2),
     ],
 )
 def test_paragraphs_many(writing_string, expected_count):
@@ -64,12 +59,9 @@ def test_paragraphs_many(writing_string, expected_count):
 @pytest.mark.parametrize(
     "writing_string,expected_count",
     [
-        ("", 0),
         ("hello world! Writing a lot.\n\nsingle.", 1),
         ("hello world! Writing a lot.\n\nnew one.", 2),
         ("hello world! Writing a lot.\n\nNew one. Question?", 3),
-        ("This should be `five` words", 5),
-        ("The command `pipenv run pytest` should test", 7),
         (
             "The method test.main was called. Hello world! Writing a lot.\n\n"
             "New one. Question? Fun!",
@@ -90,30 +82,13 @@ def test_paragraphs_many(writing_string, expected_count):
             "New one. Question? Fun! Nice!",
             5,
         ),
-        # code blocks
         (
             "Here is some code in a code block.\n\n```\ndef test_function():\n    "
             "function_call()\n```\n\nHello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
             4,
         ),
-        (
-            "Here is some code in an inline code block: `def test_function():`. "
-            "Hello world! Example? Writing.\n\n"
-            "New one. `Code?` Question? Fun! Nice!",
-            6,
-        ),
-        # images
-        (
-            "Here is some code in an inline code block: `def test_function():`. "
-            "Hello world! Example? Writing.\n\n"
-            "New one. [Image](https://example.com/image.png) Question? Fun! Nice!",
-            6,
-        ),
-        # links
-        ("[This link is five words](www.url.com)", 5),
-        # emoji
-        (":thumbsup: is an emoji", 4),
+        ("", 0),
     ],
 )
 def test_words_different_counts(writing_string, expected_count):


### PR DESCRIPTION
PR #105 adds a new dependency (`commonmark`), which GatorGradle does not handle.

GatorGradle must be updated to handle this case -- it already has, but the version number must either change, or Gradle Plugin Portal support must be contacted to replace version `0.3.3`. That is in progress at the moment, but since this breaks every existing lab currently, the PR will be reverted for now.