### PR TITLE
Revert "Revert "Implement a Markdown AST Parser""

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 gitpython = "*"
 requests = ">=2.20.0"
+commonmark = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2243de424d57eb62719bd0013f81833a16fb4a6757011762b90c6c7387cdd38a"
+            "sha256": "16e9a8d92bcfb53dce8b81d1857049ce1620c08ca57b03c35b1f3e6484d0ea17"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -27,6 +27,20 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "commonmark": {
+            "hashes": [
+                "sha256:9f6dda7876b2bb88dd784440166f4bc8e56cb2b2551264051123bacb0b6c1d8a",
+                "sha256:abcbc854e0eae5deaf52ae5e328501b78b4a0758bf98ac8bb792fce993006084"
+            ],
+            "index": "pypi",
+            "version": "==0.8.1"
+        },
+        "future": {
+            "hashes": [
+                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+            ],
+            "version": "==0.17.1"
         },
         "gitdb2": {
             "hashes": [

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -1,64 +1,56 @@
 """Retrieve and count the contents of a file"""
 
 from pathlib import Path
-import re
+
+import commonmark
 
 from gator import util
 
 FILE_SEPARATOR = "/"
 
-# References:
-# https://stackoverflow.com/questions/18568105/how-match-a-paragraph-using-regex
-# https://stackoverflow.com/questions/13531204/how-to-match-paragraphs-in-text-with-regx
-
-CODE_FENCE_MARKER = "```"
-GATORGRADER_REPLACEMENT = "GATORGRADER_REPLACEMENT"
-PARAGRAH_RE = r"(.+?\n\n|.+?$)"
-SECTION_MARKER = "#"
-
 NEWLINE = "\n"
 NOTHING = ""
 SPACE = " "
 
-DOUBLE_NEWLINE = NEWLINE * 2
 
-
-def is_paragraph(candidate):
-    """Determines if a writing candidate is a paragraph"""
-    # remove whitespace surrounding candidate paragraph
-    candidate = candidate.strip()
-    # if the paragraph is a markdown header, it is not a paragraph
-    if candidate.startswith(SECTION_MARKER):
-        return False
-    # if the paragraph is a fenced code block, it is not a paragraph
-    if candidate.startswith(CODE_FENCE_MARKER):
-        return False
-    # there may be other edge cases that should be added here in the
-    # future -- what other structures look like paragraphs but should
-    # not be?
-    # if nothing has returned by now, the candidate must be a paragraph
-    return True
-
-
-def get_paragraphs(contents, blank_replace=True):
+def get_paragraphs(contents):
     """Retrieves the paragraphs in the writing"""
-    # use a replacement to handle a string with just spaces
-    if blank_replace is True:
-        contents = contents.replace(SPACE, NOTHING)
-    # replace a single newline with a blank space, respecting double newlines
-    contents = contents.replace(DOUBLE_NEWLINE, GATORGRADER_REPLACEMENT)
-    contents = contents.replace(NEWLINE, SPACE)
-    contents = contents.replace(GATORGRADER_REPLACEMENT, DOUBLE_NEWLINE)
-    pattern = re.compile(PARAGRAH_RE)
-    paragraphs = pattern.findall(contents)
-    # disregard all of the section headers in markdown
-    matching_paragraphs = []
-    # iterate through all potential paragraphs and gather
-    # those that match the standard for legitimacy
-    for paragraph in paragraphs:
-        if is_paragraph(paragraph) is True:
-            matching_paragraphs.append(paragraph)
-    return matching_paragraphs
+    ast = commonmark.Parser().parse(contents)
+    mode_looking = True
+    paragraph_list = []
+    paragraph_content = ""
+    counter = 0
+
+    # Iterate through the markdown to find paragraphs and add their contents to paragraph_list
+    for subnode, enter in ast.walker():
+        if mode_looking:
+            # Check to see if the current subnode is an open paragraph node
+            if counter == 1 and subnode.t == "paragraph" and enter:
+                # Initialize paragraph_content
+                paragraph_content = ""
+                # Stop search for paragraph nodes, as one has been found
+                # Instead, start adding content to paragraph_content
+                mode_looking = False
+        else:
+            # Check to see if the current subnode is a closing paragraph node
+            if counter == 2 and subnode.t == "paragraph" and not enter:
+                # Add the content of the paragraph to paragraph_list
+                paragraph_list.append(paragraph_content)
+                # Stop saving paragraph contents, as the paragraph had ended
+                # Start a search for a new paragraph
+                mode_looking = True
+            # If the subnode literal has contents, add them to paragraph_content
+            if subnode.literal is not None:
+                paragraph_content += subnode.literal
+
+        # Track the how deep into the tree the search currently is
+        if subnode.is_container():
+            if enter:
+                counter += 1
+            else:
+                counter -= 1
+
+    return paragraph_list
 
 
 def get_line_list(content):
@@ -89,16 +81,14 @@ def is_blank_line(line):
 
 def count_paragraphs(contents):
     """Counts the number of paragraphs in the writing"""
-    replace_blank_inputs = True
-    matching_paragraphs = get_paragraphs(contents, replace_blank_inputs)
+    matching_paragraphs = get_paragraphs(contents)
     return len(matching_paragraphs)
 
 
 def count_words(contents):
     """Counts the minimum number of words across all paragraphs in writing"""
     # retrieve all of the paragraphs in the contents
-    replace_blank_inputs = False
-    paragraphs = get_paragraphs(contents, replace_blank_inputs)
+    paragraphs = get_paragraphs(contents)
     # count all of the words in each paragraph
     word_counts = []
     for para in paragraphs:

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -15,24 +15,21 @@ from gator import fragments
         ("hello world!!%^(@after)writing a lot\n", 1),
         ("hello world!!%^(@after)writing a lot\n\n", 1),
         ("", 0),
-        ("", 0),
-        (" ", 0),
         (" ", 0),
         ("     ", 0),
-        ("     ", 0),
-        ("a     ", 1),
         ("a     ", 1),
         ("a\n     ", 1),
+        # headers
         ("# Section Header", 0),
         ("# Section Header\n\nNot Section Header", 1),
         ("Paragraph\n\n\n# Section Header", 1),
+        # lists
+        ("Paragraph1\n - first item\n - second item", 1),
+        (" - first item\n - second item\n", 0),
+        # code blocks
         ("Paragraph\n\n```\nShould not be a paragraph\n```", 1),
         ("```\nShould not be\na paragraph\n```", 0),
-        (
-            "Beginning of paragraph ``` Still in fences but now \
-    also in paragraph ``` and end",
-            1,
-        ),
+        ("Paragraph `inline code block` and end", 1),
     ],
 )
 def test_paragraphs_zero_or_one(writing_string, expected_count):
@@ -48,7 +45,15 @@ def test_paragraphs_zero_or_one(writing_string, expected_count):
         ("hello world\n\nhi\n\nff!$@name", 3),
         ("hello world\n\nhi\n\nff!$@name\n\n^^44", 4),
         ("hello world 44\n\nhi\n\nff!$@name\n\n^^44", 4),
+        # headers
         ("# Section Header\n\nhello world 44\n\nhi\n\nff!$@name\n\n^^44", 4),
+        # lists
+        ("Paragraph1\n 1. item one\n 2. item two\n\nParagraph2", 2),
+        # Thematic, line and soft breaks
+        ("** ***", 0),
+        ("This is one paragraph.\n___\nThis is another paragraph.", 2),
+        ("Line break.  \nHello\\\nLine break.", 1),
+        ("This is a soft break\n\nThis is the second paragraph", 2),
     ],
 )
 def test_paragraphs_many(writing_string, expected_count):
@@ -59,9 +64,12 @@ def test_paragraphs_many(writing_string, expected_count):
 @pytest.mark.parametrize(
     "writing_string,expected_count",
     [
+        ("", 0),
         ("hello world! Writing a lot.\n\nsingle.", 1),
         ("hello world! Writing a lot.\n\nnew one.", 2),
         ("hello world! Writing a lot.\n\nNew one. Question?", 3),
+        ("This should be `five` words", 5),
+        ("The command `pipenv run pytest` should test", 7),
         (
             "The method test.main was called. Hello world! Writing a lot.\n\n"
             "New one. Question? Fun!",
@@ -82,13 +90,30 @@ def test_paragraphs_many(writing_string, expected_count):
             "New one. Question? Fun! Nice!",
             5,
         ),
+        # code blocks
         (
             "Here is some code in a code block.\n\n```\ndef test_function():\n    "
             "function_call()\n```\n\nHello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
             4,
         ),
-        ("", 0),
+        (
+            "Here is some code in an inline code block: `def test_function():`. "
+            "Hello world! Example? Writing.\n\n"
+            "New one. `Code?` Question? Fun! Nice!",
+            6,
+        ),
+        # images
+        (
+            "Here is some code in an inline code block: `def test_function():`. "
+            "Hello world! Example? Writing.\n\n"
+            "New one. [Image](https://example.com/image.png) Question? Fun! Nice!",
+            6,
+        ),
+        # links
+        ("[This link is five words](www.url.com)", 5),
+        # emoji
+        (":thumbsup: is an emoji", 4),
     ],
 )
 def test_words_different_counts(writing_string, expected_count):


### PR DESCRIPTION
Reverts GatorEducator/gatorgrader#116

Now that GatorGradle has had an emergency update to handle this eventuality, discussion should begin on whether to merge this.

## NOTE
This will break all labs using GatorGradle `0.3.2` or lower, since the code to run `pipenv install --deploy` during GatorGrader updating exists only in `0.3.3` and beyond. This can of course be fixed be deleting the GatorGrader installation -- then any version will redownload and install the dependencies again.