### PR TITLE
Add diagnostic for exists check

### DIFF
--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -66,7 +66,8 @@ def invoke_file_in_directory_check(filecheck, directory):
     # produce the final report and return the result
     # note that update_report is not called because
     # there will never be a diagnostic for this invoke
-    report.add_result(message, was_file_found, NO_DIAGNOSTIC)
+    diagnostic = "Did not find file"
+    report.add_result(message, was_file_found, diagnostic)
     return was_file_found
 
 

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -43,9 +43,11 @@ def test_file_exists_in_directory_check(reset_results_dictionary, tmpdir):
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "sub"
     hello_file = "hello.txt"
     invoke.invoke_file_in_directory_check(hello_file, directory)
-    details = report.get_details()
+    details = report.get_detail(0)
     assert details is not None
-
+    # assert details["outcome"] is True
+    assert details["diagnostic"] is not None
+    assert details["diagnostic"]
 
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -49,6 +49,7 @@ def test_file_exists_in_directory_check(reset_results_dictionary, tmpdir):
     assert details["diagnostic"] is not None
     assert details["diagnostic"]
 
+
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
 def test_file_exists_in_directory_check_paragraphs(reset_results_dictionary, tmpdir):

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -113,7 +113,7 @@ def test_perform_actions_display_welcome_and_ready_check_exists(
     captured = capsys.readouterr()
     counted_newlines = captured.out.count("\n")
     assert "GatorGrader" in captured.out
-    assert counted_newlines == 6
+    assert counted_newlines == 7
     assert exit_code == 1
 
 


### PR DESCRIPTION
A diagnostic message ("Did not find file") was added to the existence check of GatorGrader.

We also edited and fixed a test for orchestrate and a test for the existence check.