### PR TITLE
Add setup config file for mutmut mutation testing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ flake8 = "*"
 pytest-cov = "*"
 pytest-sugar = "*"
 neovim = "*"
+mutmut = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2243de424d57eb62719bd0013f81833a16fb4a6757011762b90c6c7387cdd38a"
+            "sha256": "dfd95da88f8bd7bc96eb87c1ecc54a8f1bfee720243ab2f6eb2c50e71c98b11c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,10 +16,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -112,10 +112,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -188,6 +188,12 @@
             "index": "pypi",
             "version": "==3.7.7"
         },
+        "glob2": {
+            "hashes": [
+                "sha256:f5b0a686ff21f820c4d3f0c4edd216704cea59d79d00fa337e244a2f2ff83ed6"
+            ],
+            "version": "==0.6"
+        },
         "greenlet": {
             "hashes": [
                 "sha256:000546ad01e6389e98626c1367be58efa613fa82a1be98b0c6fc24b563acc6d0",
@@ -221,10 +227,16 @@
         },
         "isort": {
             "hashes": [
-                "sha256:38a74a5ccf3a15a7a99f975071164f48d4d10eed4154879009c18e6e8933e5aa",
-                "sha256:abbb2684aa234d5eb8a67ef36d4aa62ea080d46c2eba36ad09e2990ae52e4305"
+                "sha256:18c796c2cd35eb1a1d3f012a214a542790a1aed95e29768bdcb9f2197eccbd0b",
+                "sha256:96151fca2c6e736503981896495d344781b60d18bfda78dc11b290c6125ebdb6"
             ],
-            "version": "==4.3.13"
+            "version": "==4.3.15"
+        },
+        "junit-xml": {
+            "hashes": [
+                "sha256:602f1c480a19d64edb452bf7632f76b5f2cb92c1938c6e071dcda8ff9541dc21"
+            ],
+            "version": "==1.8"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -297,6 +309,13 @@
             ],
             "version": "==0.6.1"
         },
+        "mutmut": {
+            "hashes": [
+                "sha256:b97440113dc9b46aa024070e26ecd04acc5c8d8e0f40f4337b24b9326ce91a52"
+            ],
+            "index": "pypi",
+            "version": "==1.3.1"
+        },
         "neovim": {
             "hashes": [
                 "sha256:a6a0e7a5b4433bf4e6ddcbc5c5ff44170be7d84259d002b8e8d8fb4ee78af60f"
@@ -311,12 +330,25 @@
             ],
             "version": "==19.0"
         },
+        "parso": {
+            "hashes": [
+                "sha256:4580328ae3f548b358f4901e38c0578229186835f0fa0846e47369796dd5bcc9",
+                "sha256:68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db"
+            ],
+            "version": "==0.3.4"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
                 "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
             ],
             "version": "==0.9.0"
+        },
+        "pony": {
+            "hashes": [
+                "sha256:2fdc41d9dcf2b6e70dd0623e328f31349b559b8f5e83996f9272bac4fd7b279c"
+            ],
+            "version": "==0.7.9"
         },
         "py": {
             "hashes": [
@@ -362,11 +394,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
-                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
+                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
+                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
             ],
             "index": "pypi",
-            "version": "==4.3.0"
+            "version": "==4.3.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -412,6 +444,19 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "tri.declarative": {
+            "hashes": [
+                "sha256:e661d95f8537bcbb666f07799ba8594478c21f27defc458d2b28aa9682c3c597"
+            ],
+            "version": "==1.1.0"
+        },
+        "tri.struct": {
+            "hashes": [
+                "sha256:1ab4804ca6e174e346df3110fbe580a1ce347b646c97542ec5f34861e528936a",
+                "sha256:37971c2c234ebf7db3c8ec6af8f5dd1771062b8519e7eddcd651d06e3f165cea"
+            ],
+            "version": "==2.5.7"
         },
         "typed-ast": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[tool:pytest]
+testpaths=gatorgrader/tests
+
+[mutmut]
+paths_to_mutate=gator
+backup=False
+tests_dir=tests
+runner=pipenv run python -m pytest


### PR DESCRIPTION
This PR will fix #66. You can now perform mutation testing to assess the adequacy of the test suite using mutmut mutation system 