### PR TITLE
Fix critical word counting bug

### DIFF
--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -36,12 +36,15 @@ def get_paragraphs(contents):
             # Check to see if the current subnode is a closing paragraph node
             if counter == 2 and subnode.t == "paragraph" and not enter:
                 # Add the content of the paragraph to paragraph_list
-                paragraph_list.append(paragraph_content)
+                paragraph_list.append(paragraph_content.strip())
                 # Stop saving paragraph contents, as the paragraph had ended
                 # Start a search for a new paragraph
                 mode_looking = True
-            # If the subnode literal has contents, add them to paragraph_content
-            if subnode.literal is not None:
+            # If the subnode literal has contents,
+            # or is a softbreak, add them to paragraph_content
+            if subnode.t == "softbreak":
+                paragraph_content += NEWLINE
+            elif subnode.literal is not None:
                 paragraph_content += subnode.literal
 
         # Track the how deep into the tree the search currently is

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -89,17 +89,19 @@ def count_paragraphs(contents):
 def count_words(contents):
     """Counts the minimum number of words across all paragraphs in writing"""
     # retrieve all of the paragraphs in the contents
+    # NOTE: this causes word counting to only be supported for markdown!
     paragraphs = get_paragraphs(contents)
     # count all of the words in each paragraph
     word_counts = []
     for para in paragraphs:
-        para = para.replace(NEWLINE, SPACE)
-        words = NOTHING.join(ch if ch.isalnum() else SPACE for ch in para).split()
+        # split the string by whitespace (newlines, spaces, etc.)
+        words = para.split()
         word_counts.append(len(words))
     # return the minimum number of words across all paragraphs
     if word_counts:
         return min(word_counts)
-    # counting did not work correctly, so return 0
+    # counting did not work correctly (probably because there were
+    # no paragraphs), so return 0
     return 0
 
 

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -69,6 +69,7 @@ def test_paragraphs_many(writing_string, expected_count):
         ("hello world! Writing a lot.\n\nnew one.", 2),
         ("hello world! Writing a lot.\n\nNew one. Question?", 3),
         ("This should be `five` words", 5),
+        ("This should still be `six` word's", 6),
         ("The command `pipenv run pytest` should test", 7),
         (
             "The method test.main was called. Hello world! Writing a lot.\n\n"
@@ -114,10 +115,14 @@ def test_paragraphs_many(writing_string, expected_count):
         ("[This link is five words](www.url.com)", 5),
         # emoji
         (":thumbsup: is an emoji", 4),
+        # new lines
+        ("One sentence is\nanother's problem.", 5),
+        ("One sentence's\ngreat delusion.", 4),
     ],
 )
 def test_words_different_counts(writing_string, expected_count):
     """Check that it can detect different counts of words"""
+    # only check the minimum count
     assert fragments.count_words(writing_string) == expected_count
 
 


### PR DESCRIPTION
This occurs when there is a newline in a paragraph -- the word right before and right after are merged, and thus the word count is incorrect.

This PR fixes that bug as well as simplifying some related word counting code.
It also adds test cases that fail at first and now pass.