### PR TITLE
Fixed link to Python website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Python comes pre-installed on many different distributions, and is available as
 a package on most systems. However, there are certain features you might want
 to use that are not available on your distro’s package. Simply google `python
 download` for your OS or follow the download and installation instructions on
-[the Python website](python.org).
+[the Python website](https://www.python.org/).
 
 [Pipenv](https://github.com/pypa/pipenv) is used by GatorGrader to create a
 virtual environment, install and manage packages, and run Python commands. To


### PR DESCRIPTION
Clicking on "the Python's website." directs the user to ERROR 404 because it is not found. It should direct the user to "www://https.python.org" instead.

Fixes issue #147 

#### What is the current behavior?
Clicking on "the Python's website." directs the user to ERROR 404 because it is not found.

#### What is the new behavior if this PR is merged?
Clicking on "the Python's website." correctly directs the user to "www://https.python.org".

* **This PR has:**
- [x] Commit messages that are correctly formatted
- [x] Tests for newly introduced code
- [x] Docsrings for newly introduced code

**Developers**
@hodevin
