### PR TITLE
Fix typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,8 @@
 
 ##### Other information
 
-* **This PR has:**
+**This PR has:**
+
 - [ ] Commit messages that are correctly formatted
 - [ ] Tests for newly introduced code
 - [ ] Docstrings for newly introduced code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,18 @@
 <!-- A short description can be included here -->
 <!-- Please ensure that reviewers are assigned -->
 
-#### What is the current behavior?
+### What is the current behavior?
 <!-- You can link to an open issue here -->
 
 
 
-#### What is the new behavior if this PR is merged?
+### What is the new behavior if this PR is merged?
 
 
 
-##### Other information
+#### Other information
 
-**This PR has:**
+##### This PR has:
 
 - [ ] Commit messages that are correctly formatted
 - [ ] Tests for newly introduced code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 * **This PR has:**
 - [ ] Commit messages that are correctly formatted
 - [ ] Tests for newly introduced code
-- [ ] Docsrings for newly introduced code
+- [ ] Docstrings for newly introduced code
 
 This PR is a <!-- REQUIRED: replace this comment with one of ["small change", "feature", "compatibility breaking update", "non-versioned change"] -->
 that fixes #<!-- replace this comment with an issue number if applicable -->


### PR DESCRIPTION
`docstrings` was misspelled in the PR template; some formatting was also changed.

#### Other information

##### This PR has:

- [x] Commit messages that are correctly formatted
- [x] Tests for newly introduced code
- [x] Docstrings for newly introduced code

This PR is a small change.

**Developers**

@Michionlion 
