### PR TITLE
Add total-words to check the number of words in a file

### DIFF
--- a/gator/arguments.py
+++ b/gator/arguments.py
@@ -72,12 +72,16 @@ def parse(args):
     )
 
     # specify a check on words
-    # note that sentences are no longer supported so, a "dest" given
     # CORRECT WHEN: user provides file and directory along with this argument
     gg_parser.add_argument(
         "--words", type=int, help="minimum number of words in paragraphs"
     )
 
+    # specify a check on total words
+    # CORRECT WHEN: user provides file and directory along with this argument
+    gg_parser.add_argument(
+        "--total-words", type=int, help="minimum number of words in a file"
+    )
     # }}}
 
     # specify a command to run for checking
@@ -242,6 +246,14 @@ def is_valid_words(args, skip=False):
     return False
 
 
+def is_valid_total_words(args, skip=False):
+    """Checks if it is a valid total-words specification"""
+    if is_valid_file_and_directory(args) or skip:
+        if args.total_words is not None:
+            return True
+    return False
+
+
 def is_valid_language(args, skip=False):
     """Checks if it is a valid language specification"""
     if (is_valid_file_and_directory(args) and is_valid_comments(args)) or skip:
@@ -292,6 +304,7 @@ def is_file_ancillary(args):
         or is_valid_comments(args, skip=True)
         or is_valid_paragraphs(args, skip=True)
         or is_valid_words(args, skip=True)
+        or is_valid_total_words(args, skip=True)
     ):
         return True
     return False
@@ -345,6 +358,10 @@ def verify(args):
             file_verified.append(True)
         # VERIFIED: correct check for words in a file in a directory
         if is_valid_words(args):
+            # verified_arguments = True
+            file_verified.append(True)
+        # VERIFIED: correct check for total words in a file in a directory
+        if is_valid_total_words(args):
             # verified_arguments = True
             file_verified.append(True)
         # VERIFIED: correct check for fragments in a file in a directory

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -108,6 +108,24 @@ def count_words(contents):
     return 0
 
 
+def count_total_words(contents):
+    """Counts the total number of words in writing"""
+    # retrieve all of the paragraphs in the contents
+    # NOTE: this causes word counting to only be supported for markdown!
+    paragraphs = get_paragraphs(contents)
+    # count all of the words in each paragraph
+    word_counts = []
+    for para in paragraphs:
+        # split the string by whitespace (newlines, spaces, etc.) and punctuation
+        words = re.sub(r"[!\"#$%&()*+,\./:;\<=\>\?\@\[\]\^`\{\|\}]", " ", para).split()
+        word_counts.append(len(words))
+    if word_counts:
+        return sum(word_counts)
+    # counting did not work correctly (probably because there were
+    # no paragraphs), so return 0
+    return 0
+
+
 def count_specified_fragment(contents, fragment):
     """Counts the specified string fragment in the string contents"""
     fragment_count = contents.count(fragment)

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -223,6 +223,42 @@ def invoke_all_word_count_checks(filecheck, directory, expected_count, exact=Fal
     return met_or_exceeded_count
 
 
+def invoke_all_total_word_count_checks(filecheck, directory, expected_count, exact=False):
+    """Perform the word count check and return the results"""
+    met_or_exceeded_count = 0
+    met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+        filecheck, directory, expected_count, fragments.count_total_words
+    )
+    # create the message and the diagnostic
+    if not exact:
+        message = (
+            "The "
+            + filecheck
+            + " in "
+            + directory
+            + " has at least "
+            + str(expected_count)
+            + SPACE
+            + "word(s) in total"
+        )
+    else:
+        message = (
+            "The "
+            + filecheck
+            + " in "
+            + directory
+            + " has exactly "
+            + str(expected_count)
+            + SPACE
+            + "word(s) in total"
+        )
+    diagnostic = (
+        "Found " + str(actual_count) + " word(s) in the specified file"
+    )
+    report_result(met_or_exceeded_count, message, diagnostic)
+    return met_or_exceeded_count
+
+
 # pylint: disable=bad-continuation
 def invoke_all_fragment_checks(
     fragment,

--- a/gator/orchestrate.py
+++ b/gator/orchestrate.py
@@ -163,6 +163,25 @@ def check_words(system_arguments):
     return actions
 
 
+def check_total_words(system_arguments):
+    """Check the total word count in a file and return desired actions"""
+    actions = []
+    if system_arguments.total_words is not None:
+        actions.append(
+            [
+                INVOKE,
+                "invoke_all_total_word_count_checks",
+                [
+                    system_arguments.file,
+                    system_arguments.directory,
+                    system_arguments.total_words,
+                    system_arguments.exact,
+                ],
+            ]
+        )
+    return actions
+
+
 def check_fragment_file(system_arguments):
     """Check the existence of fragment in a file and return desired actions"""
     actions = []
@@ -364,6 +383,7 @@ def check(system_arguments):
         "check_multiple",
         "check_paragraphs",
         "check_words",
+        "check_total_words",
         "check_markdown_file",
         "check_fragment_file",
         "check_fragment_command",

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -645,6 +645,33 @@ def test_is_valid_words_valid(chosen_arguments):
 
 
 @pytest.mark.parametrize(
+    "chosen_arguments,validity",
+    [
+        (["--nowelcome", "--directory", "D", "--file", "f", "--total-words", "2"], True),
+        (["--nowelcome", "--file", "f", "--directory", "D", "--total-words", "2"], True),
+        (["--file", "f", "--directory", "D", "--total-words", "2"], True),
+        (["--directory", "D", "--file", "F", "--total-words", "2"], True),
+        (["--nowelcome"], False),
+        (["--nowelcome", "--directory", "D", "--total-words", "2"], False),
+        (["--directory", "D", "--total-words", "2"], False),
+        (["--nowelcome", "--file", "F", "--total-words", "1"], False),
+        (["--file", "F", "--total-words", "1"], False),
+        (["--directory", "D", "--file", "F", "--single", "1"], False),
+        (["--directory", "D", "--file", "F", "--multiple", "1"], False),
+        (["--directory", "D", "--file", "F", "--paragraphs", "1"], False),
+        # This is true, but should be false after verify() since words will also be true
+        (["--directory", "D", "--file", "F", "--total-words", "4", "--words", "2"], True),
+        (["--directory", "D", "--file", "F", "--words", "4", "--total-words", "2"], True),
+    ],
+)
+def test_is_valid_total_words(chosen_arguments, validity):
+    """Check that valid argument combinations do not verify correctly"""
+    parsed_arguments = arguments.parse(chosen_arguments)
+    verified_arguments = arguments.is_valid_total_words(parsed_arguments)
+    assert verified_arguments is validity
+
+
+@pytest.mark.parametrize(
     "chosen_arguments",
     [
         (["--nowelcome", "--command", "run", "--paragraphs", "3"]),

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -110,6 +110,8 @@ def test_module_argument_not_verifiable_syserror(chosen_arguments, capsys):
         (["--file", "f", "--directory", "D", "--single", "2"]),
         (["--file", "f", "--directory", "D", "--multiple", "2", "--executes"]),
         (["--file", "f", "--directory", "D", "--single", "2", "--executes"]),
+        (["--file", "f", "--directory", "D", "--total-words", "2", "--words", "4"]),
+        (["--file", "f", "--directory", "D", "--words", "2", "--total-words", "4"]),
         (["--nowelcome", "--command", "run", "--paragraphs", "3"]),
         (["--nowelcome", "--command", "run", "--paragraphs", "3", "--executes"]),
         (

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -127,6 +127,71 @@ def test_words_different_counts(writing_string, expected_count):
 
 
 @pytest.mark.parametrize(
+    "writing_string,expected_count",
+    [
+        ("", 0),
+        ("hello world! Writing a lot.\n\nsingle.", 6),
+        ("hello world! Writing a lot.\n\nnew one.", 7),
+        ("hello world! Writing a lot.\n\nNew one. Question?", 8),
+        ("This should be `five` words", 5),
+        ("This should still be `six` word's", 6),
+        ("The command `pipenv run pytest` should test", 7),
+        (
+            "The method test.main was called. Hello world! Writing a lot.\n\n"
+            "New one. Question? Fun!",
+            15,
+        ),
+        (
+            "New one. Question? Fun! Nice!\n\n"
+            "The method test.main was called. Hello world! Writing a lot.",
+            16,
+        ),
+        (
+            "The method `test.main` was called. Hello world! Example? Writing.\n\n"
+            "New one. Question? Fun! Nice!",
+            15,
+        ),
+        (
+            "The method test.main was called.\nHello world! Example? Writing.\n\n"
+            "New one. Question? Fun! Nice!",
+            15,
+        ),
+        # code blocks
+        (
+            "Here is some code in a code block.\n\n```\ndef test_function():\n    "
+            "function_call()\n```\n\nHello world! Example? Writing.\n\n"
+            "New one. Question? Fun! Nice!",
+            17,
+        ),
+        (
+            "Here is some code in an inline code block: `def test_function():`. "
+            "Hello world! Example? Writing.\n\n"
+            "New one. `Code?` Question? Fun! Nice!",
+            21,
+        ),
+        # images
+        (
+            "Here is some code in an inline code block: `def test_function():`. "
+            "Hello world! Example? Writing.\n\n"
+            "New one. [Image](https://example.com/image.png) Question? Fun! Nice!",
+            21,
+        ),
+        # links
+        ("[This link is five words](www.url.com)", 5),
+        # emoji
+        (":thumbsup: is an emoji", 4),
+        # new lines
+        ("One sentence is\nanother's problem.", 5),
+        ("One sentence's\ngreat delusion.", 4),
+    ],
+)
+def test_total_words_different_counts(writing_string, expected_count):
+    """Check that it can detect different counts of total words"""
+    # only check the minimum count
+    assert fragments.count_total_words(writing_string) == expected_count
+
+
+@pytest.mark.parametrize(
     "writing_string,chosen_fragment,expected_count",
     [
         ("hello world!!%^(@after)writing a lot\n\nnew one", "writing", 1),

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -141,6 +141,54 @@ def test_file_exists_in_directory_check_words_exact(reset_results_dictionary, tm
 
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
+def test_file_exists_in_directory_check_total_words(reset_results_dictionary, tmpdir):
+    """Checks that the checking of total words works correctly"""
+    reflection_file = tmpdir.mkdir("sub").join("reflection.md")
+    reflection_file.write(
+        "hello world 44 fine\n\nhi there nice again\n\nff! Is now $@name again\n\n"
+    )
+    assert (
+        reflection_file.read()
+        == "hello world 44 fine\n\nhi there nice again\n\nff! Is now $@name again\n\n"
+    )
+    assert len(tmpdir.listdir()) == 1
+    directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "sub"
+    reflection_file = "reflection.md"
+    invoke.invoke_all_total_word_count_checks(reflection_file, directory, 12)
+    details = report.get_result()
+    assert details is not None
+    report.reset()
+    invoke.invoke_all_total_word_count_checks(reflection_file, directory, 100)
+    details = report.get_result()
+    assert details is not None
+
+
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+def test_file_exists_in_directory_check_total_words_exact(reset_results_dictionary, tmpdir):
+    """Checks that the checking of total words works exactly correctly"""
+    reflection_file = tmpdir.mkdir("sub").join("reflection.md")
+    reflection_file.write(
+        "hello world 44 fine\n\nhi there nice again\n\nff! Is now $@name again\n\n"
+    )
+    assert (
+        reflection_file.read()
+        == "hello world 44 fine\n\nhi there nice again\n\nff! Is now $@name again\n\n"
+    )
+    assert len(tmpdir.listdir()) == 1
+    directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "sub"
+    reflection_file = "reflection.md"
+    invoke.invoke_all_total_word_count_checks(reflection_file, directory, 12, exact=True)
+    details = report.get_result()
+    assert details is not None
+    report.reset()
+    invoke.invoke_all_total_word_count_checks(reflection_file, directory, 100, exact=True)
+    details = report.get_result()
+    assert details is not None
+
+
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
 def test_file_exists_in_directory_check_fragments(reset_results_dictionary, tmpdir):
     """Checks that the checking of fragments in a file works correctly"""
     reflection_file = tmpdir.mkdir("sub").join("reflection.md")

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -245,6 +245,21 @@ def test_perform_actions_display_welcome_and_ready_check_words(
 
 # pylint: disable=redefined-outer-name
 # pylint: disable=bad-continuation
+def test_perform_actions_display_welcome_and_ready_check_totals_words(
+    capsys, reset_results_dictionary
+):
+    """Check the argument verification, messages, and continue"""
+    chosen_arguments = ["--directory", "D", "--file", "f", "--total-words", "2"]
+    exit_code = orchestrate.check(chosen_arguments)
+    captured = capsys.readouterr()
+    counted_newlines = captured.out.count("\n")
+    assert "GatorGrader" in captured.out
+    assert counted_newlines == 7
+    assert exit_code == 1
+
+
+# pylint: disable=redefined-outer-name
+# pylint: disable=bad-continuation
 def test_perform_actions_display_welcome_and_ready_check_fragment_file(
     capsys, reset_results_dictionary
 ):


### PR DESCRIPTION
This adds a `total-words <num> check that counts the number of words in the entire file, instead of per paragraph as `words` does. The usage is exactly the same as `words`.

### What is the current behavior?
Students often have a word count required per topic, but some topics can elicit a much longer response than others. Therefore there is often a big miss-match between the minimum and maximum words per paragraph.



### What is the new behavior if this PR is merged?
A new feature is added with this change that enables checking for an amount of total content instead of content per paragraph. This should better match the objective of ensuring students as enough content. It can even be used in conjunction with other checks (like `words` and `paragraphs`) to ensure a distribution of content in a file as well as an amount.

##### This PR has:

- [x] Commit messages that are correctly formatted
- [x] Tests for newly introduced code
- [x] Docstrings for newly introduced code

This PR is a feature update!

**Developers**

@Michionlion 
