### PR TITLE
Repository Must Handle Non-Git Directories

### DIFF
--- a/gator/constants.py
+++ b/gator/constants.py
@@ -76,7 +76,7 @@ paths = create_constants(
 results = create_constants("results", "Check", "Outcome", "Diagnostic")
 
 # define the version control repository details
-versioncontrol = create_constants("versioncontrol", Master="master")
+versioncontrol = create_constants("versioncontrol", Master="master", No_Commits=[])
 
 # define the words diagnostic messages
 words = create_constants(

--- a/gator/files.py
+++ b/gator/files.py
@@ -31,16 +31,16 @@ def create_path(*args, file="", home):
 
 
 def case_native_check_file_in_directory(*args, file, home):
-    """Return true if the case-native specified file is in the directory."""
+    """Return True if the case-native specified file is in the directory."""
     # create the path so that it has this structure:
     # <home> + <any paths in *args, without their anchor> + <file>
     file_for_checking_path = create_path(*args, file=file, home=home)
-    # return true if the specified file exists
+    # return True if the specified file exists
     return file_for_checking_path.is_file()
 
 
 def case_sensitive_check_file_in_directory(*args, file, home):
-    """Return true if the case-sensitive specified file is in the directory."""
+    """Return True if the case-sensitive specified file is in the directory."""
     # create the path so that it has this structure:
     # <home> + <any paths in *args, without their anchor> + <file>
     file_for_checking_path = create_path(*args, file=file, home=home)
@@ -63,7 +63,7 @@ def case_sensitive_check_file_in_directory(*args, file, home):
 
 
 def check_file_in_directory(*args, file, home):
-    """Return true if the specified file is in the directory."""
+    """Return True if the specified file is in the directory."""
     # perform the standard check that relies on the operating system
     # to determine whether or not the file exists on the file system
     no_case_file_exists = case_native_check_file_in_directory(

--- a/gator/repository.py
+++ b/gator/repository.py
@@ -1,17 +1,38 @@
 """Interact with a Git repository."""
 
-from git import Repo
+import git
 
+from gator import constants
 from gator import util
 
 
-def get_commmits(path):
-    """Return a list of the commits for the repo at path."""
-    student_repository = Repo(path)
-    # pass in None so that the default (the current branch) is used
-    # this avoids problems with being checked out in different branches
-    # alternatively, we could detect the current HEAD and use that
-    commits = list(student_repository.iter_commits())
+def is_git_repository(repository_path):
+    """Return True if repository_path contains a Git repository, False otherwise."""
+    # attempt to create a repository using GitPython
+    try:
+        # it was possible to create the repository, so it must exist
+        # this means that the function should return True
+        # because it is safe to inspect attributes of this repository
+        _ = git.Repo(repository_path).git_dir
+        return True
+    # it was not possible to create the repository, so it does not exist
+    # this means that the function should return False
+    # because it is not safe to inspect Git attributes in this non-repo
+    except git.exc.InvalidGitRepositoryError:
+        return False
+
+
+def get_commmits(repository_path):
+    """Return a list of the commits for the repository at the path."""
+    # assume that we have not found a Git repository
+    # and thus set the default number of commits to zero
+    commits = constants.versioncontrol.No_Commits
+    if is_git_repository(repository_path):
+        student_repository = git.Repo(repository_path)
+        # pass in None so that the default (the current branch) is used
+        # this avoids problems with being checked out in different branches
+        # alternatively, we could detect the current HEAD and use that
+        commits = list(student_repository.iter_commits())
     return commits
 
 

--- a/gator/repository.py
+++ b/gator/repository.py
@@ -22,10 +22,10 @@ def is_git_repository(repository_path):
         return False
 
 
-def get_commmits(repository_path):
+def get_commits(repository_path):
     """Return a list of the commits for the repository at the path."""
     # assume that we have not found a Git repository
-    # and thus set the default number of commits to zero
+    # and thus set the default commits lists is []
     commits = constants.versioncontrol.No_Commits
     if is_git_repository(repository_path):
         student_repository = git.Repo(repository_path)
@@ -44,7 +44,7 @@ def count_commits(commits):
 def commits_greater_than_count(path, expected_count, exact=False):
     """Return count and true if count of commits is greater than limit, else False."""
     # extract the commit log and then count the commits
-    commits = get_commmits(path)
+    commits = get_commits(path)
     number_commits = count_commits(commits)
     # check the condition and also return number_commits
     return util.greater_than_equal_exacted(number_commits, expected_count, exact)

--- a/gator/repository.py
+++ b/gator/repository.py
@@ -49,7 +49,7 @@ def count_commits(commits):
 
 
 def commits_greater_than_count(path, expected_count, exact=False):
-    """Return count and true if count of commits is greater than limit, else False."""
+    """Return count and True if count of commits is greater than limit, else False."""
     # extract the commit log and then count the commits
     commits = get_commits(path)
     number_commits = count_commits(commits)

--- a/gator/repository.py
+++ b/gator/repository.py
@@ -31,13 +31,13 @@ def get_commits(repository_path):
         # the repository_path is a Git repository
         # Try to extract the commits from the repository
         # and return the list of commits if they are available.
+        student_repository = git.Repo(repository_path)
+        try:
+            commits = list(student_repository.iter_commits())
         # In circumstances in which this does not work
         # (e.g., it is a Git repository with no commits)
         # then catch the ValueError, pass, and return the
         # commits as the empty list created previously
-        student_repository = git.Repo(repository_path)
-        try:
-            commits = list(student_repository.iter_commits())
         except ValueError:
             pass
     return commits

--- a/gator/repository.py
+++ b/gator/repository.py
@@ -16,8 +16,8 @@ def is_git_repository(repository_path):
         _ = git.Repo(repository_path).git_dir
         return True
     # it was not possible to create the repository, so it does not exist
-    # this means that the function should return False
-    # because it is not safe to inspect Git attributes in this non-repo
+    # this means that the function should return False to signal
+    # that it is not safe to inspect Git attributes in this non-repo
     except git.exc.InvalidGitRepositoryError:
         return False
 
@@ -28,11 +28,18 @@ def get_commits(repository_path):
     # and thus set the default commits lists is []
     commits = constants.versioncontrol.No_Commits
     if is_git_repository(repository_path):
+        # the repository_path is a Git repository
+        # Try to extract the commits from the repository
+        # and return the list of commits if they are available.
+        # In circumstances in which this does not work
+        # (e.g., it is a Git repository with no commits)
+        # then catch the ValueError, pass, and return the
+        # commits as the empty list created previously
         student_repository = git.Repo(repository_path)
-        # pass in None so that the default (the current branch) is used
-        # this avoids problems with being checked out in different branches
-        # alternatively, we could detect the current HEAD and use that
-        commits = list(student_repository.iter_commits())
+        try:
+            commits = list(student_repository.iter_commits())
+        except ValueError:
+            pass
     return commits
 
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -72,6 +72,7 @@ def test_results_constant_defined():
 def test_versioncontrol_constant_defined():
     """Check correctness for the variables in the versioncontrol constant."""
     assert constants.versioncontrol.Master == "master"
+    assert constants.versioncontrol.No_Commits == []
 
 
 def test_words_constant_defined():
@@ -179,6 +180,7 @@ def test_versioncontrol_constant_cannot_redefine():
     """Check cannot redefine the variables in the versioncontrol constant."""
     with pytest.raises(AttributeError):
         constants.versioncontrol.Master = CANNOT_SET_CONSTANT_VARIABLE
+        constants.versioncontrol.No_Commits = CANNOT_SET_CONSTANT_VARIABLE
 
 
 def test_words_constant_cannot_redefine():

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -61,6 +61,14 @@ def test_detect_git_repository(tmpdir):
     assert detected_git_repository is True
 
 
+def test_nocrash_when_not_repository(tmpdir):
+    """Ensure that a get_commits not in a repository does not crash."""
+    # since there is, by default, no repository in tmpdir
+    # then a call to get_commits will will return an empty list
+    commits = repository.get_commits(str(tmpdir))
+    assert len(commits) == 0
+
+
 def test_no_commits_in_new_git_repository(tmpdir):
     """Ensure that it is possible to detect that a directory is not a Git repository."""
     # create a Git repository using GitPython
@@ -69,14 +77,6 @@ def test_no_commits_in_new_git_repository(tmpdir):
     # the check for the existence of a repository should be True
     detected_git_repository = repository.is_git_repository(str(tmpdir))
     assert detected_git_repository is True
-    commits = repository.get_commits(str(tmpdir))
-    assert len(commits) == 0
-
-
-def test_nocrash_when_not_repository(tmpdir):
-    """Ensure that a get_commits not in a repository does not crash."""
-    # since there is, by default, no repository in tmpdir
-    # then a call to get_commits will will return an empty list
     commits = repository.get_commits(str(tmpdir))
     assert len(commits) == 0
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -79,3 +79,22 @@ def test_nocrash_when_not_repository(tmpdir):
     # then a call to get_commits will will return an empty list
     commits = repository.get_commits(str(tmpdir))
     assert len(commits) == 0
+
+
+def test_one_commit_in_new_repository(tmpdir):
+    """Ensure that it is possible to detect one commit in a new Git repository."""
+    temp_file = tmpdir.mkdir("sub").join("hello.txt")
+    temp_file.write("content")
+    assert temp_file.read() == "content"
+    assert len(tmpdir.listdir()) == 1
+    testing_repository = Repo.init(tmpdir)
+    # create an empty file and perform a commit on it
+    testing_repository.index.add([str(temp_file)])
+    testing_repository.index.commit("Add the hello.txt file.")
+    # since the repository was created in the tmpdir
+    # the check for the existence of a repository should be True
+    detected_git_repository = repository.is_git_repository(str(tmpdir))
+    assert detected_git_repository is True
+    # since an empty file was committed, the count should be 1
+    commits = repository.get_commits(str(tmpdir))
+    assert len(commits) == 1

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -2,18 +2,20 @@
 
 import sys
 
+from git import Repo
+
 from gator import repository
 
 
 def test_repository_not_zero_commits():
     """Check to ensure that GatorGrader's repository registers."""
-    commits = repository.get_commmits(".")
+    commits = repository.get_commits(".")
     assert len(commits) > 1
 
 
 def test_repository_not_zero_commits_extra_method():
     """Check to ensure that GatorGrader's repository registers."""
-    commits = repository.get_commmits(".")
+    commits = repository.get_commits(".")
     assert repository.count_commits(commits) > 1
 
 
@@ -39,3 +41,29 @@ def test_repository_commits_not_huge_exacted():
     """Check to ensure that commit counts work correctly."""
     valid, __ = repository.commits_greater_than_count(".", sys.maxsize, True)
     assert valid is False
+
+
+def test_detect_not_git_repository(tmpdir):
+    """Ensure that it is possible to detect that a directory is not a Git repository."""
+    # by default, the tmpdir is not a Git repository
+    # the check for the existence of a repository should be False
+    detected_git_repository = repository.is_git_repository(str(tmpdir))
+    assert detected_git_repository is False
+
+
+def test_detect_git_repository(tmpdir):
+    """Ensure that it is possible to detect that a directory is not a Git repository."""
+    # create a Git repository using GitPython
+    _ = Repo.init(str(tmpdir))
+    # since the repository was created in the tmpdir
+    # the check for the existence of a repository should be True
+    detected_git_repository = repository.is_git_repository(str(tmpdir))
+    assert detected_git_repository is True
+
+
+def test_nocrash_when_not_repository(tmpdir):
+    """Ensure that a check not in a repository does not crash."""
+    # since there is, by default, no repository in tmpdir
+    # then a call to get_commits will will return an empty list
+    commits = repository.get_commits(str(tmpdir))
+    assert len(commits) == 0

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -61,8 +61,20 @@ def test_detect_git_repository(tmpdir):
     assert detected_git_repository is True
 
 
+def test_no_commits_in_new_git_repository(tmpdir):
+    """Ensure that it is possible to detect that a directory is not a Git repository."""
+    # create a Git repository using GitPython
+    _ = Repo.init(str(tmpdir))
+    # since the repository was created in the tmpdir
+    # the check for the existence of a repository should be True
+    detected_git_repository = repository.is_git_repository(str(tmpdir))
+    assert detected_git_repository is True
+    commits = repository.get_commits(str(tmpdir))
+    assert len(commits) == 0
+
+
 def test_nocrash_when_not_repository(tmpdir):
-    """Ensure that a check not in a repository does not crash."""
+    """Ensure that a get_commits not in a repository does not crash."""
     # since there is, by default, no repository in tmpdir
     # then a call to get_commits will will return an empty list
     commits = repository.get_commits(str(tmpdir))


### PR DESCRIPTION
There is a bug in the `repository` module that will cause it to crash when the `get_commits` function is called with a path parameter that does not contain a Git repository. The purpose of this PR is to fix this bug and to add test cases for the new features and checks now provided.

Please note that this PR has already merged in all of the changes for the PR #166.

This PR is a bugfix that fixes #137.