### PR TITLE
Improve and Fix Diagnostics for Paragraph Word Counting

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 gitpython = "*"
 requests = ">=2.20.0"
 commonmark = "*"
+num2words = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3434fbaf2d141479eff2513156642f08148d244089e6c654b645a11ced20d11d"
+            "sha256": "52a7cb0882b92254ec8e74112fe905dd1b7153141995d10a89086364eb90b75e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -36,6 +36,12 @@
             "index": "pypi",
             "version": "==0.9.0"
         },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
         "future": {
             "hashes": [
                 "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
@@ -63,6 +69,14 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "num2words": {
+            "hashes": [
+                "sha256:0b6e5f53f11d3005787e206d9c03382f459ef048a43c544e3db3b1e05a961548",
+                "sha256:37cd4f60678f7e1045cdc3adf6acf93c8b41bf732da860f97d301f04e611cc57"
+            ],
+            "index": "pypi",
+            "version": "==0.5.10"
         },
         "requests": {
             "hashes": [
@@ -586,9 +600,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
-            "version": "==1.11.1"
+            "version": "==1.11.2"
         },
         "zipp": {
             "hashes": [

--- a/gator/comments.py
+++ b/gator/comments.py
@@ -15,30 +15,35 @@ SINGLELINECOMMENT_RE_PYTHON = r"""^(?:[^"#\\]|\"(?:[^\"\\]|\\.)*\"|
 /(?:[^#"\\]|\\.)|/\"(?:[^\"\\]|\\.)*\"|\\.)*#(.*)$"""
 MULTILINECOMMENT_RE_PYTHON = r'^[ \t]*"""(.*?)"""[ \t]*$'
 
+# Note that all of these functions also return an empty dictionary
+# (i.e., {}) so that it matches the return signature of the
+# other analagous function that counts the words and returns
+# a dictionary of the {number of a paragraph, word count in paragraph}
+
 
 def count_singleline_java_comment(contents):
     """Count the number of singleline Java comments in the code."""
     pattern = re.compile(SINGLELINECOMMENT_RE_JAVA, re.MULTILINE | re.VERBOSE)
     matches = pattern.findall(contents)
-    return len(matches)
+    return len(matches), {}
 
 
 def count_singleline_python_comment(contents):
     """Count the number of singleline Python comments in the code."""
     pattern = re.compile(SINGLELINECOMMENT_RE_PYTHON, re.MULTILINE)
     matches = pattern.findall(contents)
-    return len(matches)
+    return len(matches), {}
 
 
 def count_multiline_java_comment(contents):
     """Count the number of multiline Java comments in the code."""
     pattern = re.compile(MULTILINECOMMENT_RE_JAVA, re.MULTILINE)
     matches = pattern.findall(contents)
-    return len(matches)
+    return len(matches), {}
 
 
 def count_multiline_python_comment(contents):
     """Count the number of multiline Python comments in the code."""
     pattern = re.compile(MULTILINECOMMENT_RE_PYTHON, re.MULTILINE | re.DOTALL)
     matches = pattern.findall(contents)
-    return len(matches)
+    return len(matches), {}

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -93,5 +93,5 @@ words = create_constants(
     In_The="in the",
     Cardinal="cardinal",
     Ordinal="ordinal",
-    Paragraph="paragraph"
+    Paragraph="paragraph",
 )

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -90,4 +90,6 @@ words = create_constants(
     Total="word(s) in total",
     In_A="in a",
     In_Every="in every",
+    Cardinal="cardinal",
+    Ordinal="ordinal"
 )

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -90,6 +90,8 @@ words = create_constants(
     Total="word(s) in total",
     In_A="in a",
     In_Every="in every",
+    In_The="in the",
     Cardinal="cardinal",
-    Ordinal="ordinal"
+    Ordinal="ordinal",
+    Paragraph="paragraph"
 )

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -85,5 +85,9 @@ versioncontrol = create_constants("versioncontrol", Master="master")
 
 # define the words diagnostic messages
 words = create_constants(
-    "words", Minimum="word(s) in every paragraph", Total="word(s) in total"
+    "words",
+    Minimum="word(s) in every paragraph",
+    Total="word(s) in total",
+    In_A="in a",
+    In_Every="in every",
 )

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -19,7 +19,7 @@ def create_constants(name, *args, **kwargs):
 arguments = create_constants("arguments", Incorrect=2, Void=[])
 
 # define the codes for return values
-codes = create_constants("codes", Error=1, Success=0)
+codes = create_constants("codes", Error=1, Success=0, No_Words=0)
 
 # define the types of comments
 comments = create_constants(

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -10,11 +10,14 @@ def entity_greater_than_count(
 ):
     """Return a count and determination if entity count is greater than expected."""
     # call the count_entities function in this module
-    file_entity_count = count_entities(
+    file_entity_count, file_entity_count_dictionary = count_entities(
         given_file, containing_directory, checking_function
     )
     # check the condition and also return file_entity_count
-    return util.greater_than_equal_exacted(file_entity_count, expected_count, exact)
+    condition_result, value = util.greater_than_equal_exacted(
+        file_entity_count, expected_count, exact
+    )
+    return condition_result, value, file_entity_count_dictionary
 
 
 def count_entities(given_file, containing_directory, checking_function):
@@ -25,11 +28,16 @@ def count_entities(given_file, containing_directory, checking_function):
     file_for_checking = files.create_path(file=given_file, home=containing_directory)
     # start the count of the number of entities at zero, assuming none found yet
     file_contents_count = 0
+    # create an empty dictionary of the counts
+    file_contents_count_dictionary = {}
     # a valid file exists and thus it is acceptable to perform the checking
     if file_for_checking.is_file():
         # extract the text from the file_for_checking
         file_contents = file_for_checking.read_text()
         # use the provided checking_function to check the contents of the file
         # note this works since Python supports passing a function to a function
-        file_contents_count = checking_function(file_contents)
-    return file_contents_count
+        # print(checking_function)
+        file_contents_count, file_contents_count_dictionary = checking_function(
+            file_contents
+        )
+    return file_contents_count, file_contents_count_dictionary

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -90,22 +90,33 @@ def count_paragraphs(contents):
 
 def count_words(contents, summarizer=min):
     """Count the total number of words in writing using a summarization function."""
+    # create a list for a count of the words in each paragraph
+    word_counts = []
+    # create a dictionary to map a paragraph number
+    # to the count of the number of words in the paragraph
+    paragraph_word_counts = {}
     # retrieve all of the paragraphs in the contents
     # word counting only works for technical writing in Markdown
     paragraphs = get_paragraphs(contents)
-    # count all of the words in each paragraph
-    word_counts = []
-    for para in paragraphs:
+    # iterate through each paragraph and count its words
+    # note that using start=1 means that enumerate will
+    # index the first paragraph with the value of 1
+    for index, para in enumerate(paragraphs, start=1):
+        # for para in paragraphs:
         # split the string by whitespace (e.g., newlines or spaces) and punctuation
         words = re.sub(WHITESPACE_RE, constants.markers.Space, para).split()
-        word_counts.append(len(words))
+        # count the number of words and keep track
+        # of the count for this paragraph in the list and dictionary
+        word_count = len(words)
+        word_counts.append(word_count)
+        paragraph_word_counts[index] = word_count
     # word counts exist in the list and thus we can use the provided
     # summarizer (e.g., a sum or a min function) to summarize the count
-    if word_counts:
-        return summarizer(word_counts)
+    if word_counts and paragraph_word_counts:
+        return summarizer(word_counts), paragraph_word_counts
     # counting did not work correctly (probably because there were
     # no paragraphs), so return 0 to indicate that there were no words
-    return constants.codes.No_Words
+    return constants.codes.No_Words, paragraph_word_counts
 
 
 def count_minimum_words(contents):

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -18,7 +18,6 @@ def get_paragraphs(contents):
     mode_looking = True
     paragraph_list = []
     counter = 0
-
     # iterate through the markdown to find paragraphs and add their contents to paragraph_list
     for subnode, enter in ast.walker():
         if mode_looking:
@@ -43,14 +42,13 @@ def get_paragraphs(contents):
                 paragraph_content += constants.markers.Newline
             elif subnode.literal is not None:
                 paragraph_content += subnode.literal
-
         # track the how deep into the tree the search currently is
         if subnode.is_container():
             if enter:
                 counter += 1
             else:
                 counter -= 1
-
+    # return the list of the collected paragraphs
     return paragraph_list
 
 

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -104,8 +104,8 @@ def count_words(contents, summarizer=min):
     if word_counts:
         return summarizer(word_counts)
     # counting did not work correctly (probably because there were
-    # no paragraphs), so return 0
-    return 0
+    # no paragraphs), so return 0 to indicate that there were no words
+    return constants.codes.No_Words
 
 
 def count_minimum_words(contents):

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -85,7 +85,11 @@ def is_blank_line(line):
 def count_paragraphs(contents):
     """Count the number of paragraphs in the writing."""
     matching_paragraphs = get_paragraphs(contents)
-    return len(matching_paragraphs)
+    # return an empty dictionary because this function is
+    # passed as a function to other functions interchangeably
+    # with the count_words function which must return two parameters:
+    # (1) the count of words and (2) the dictionary of word counts
+    return len(matching_paragraphs), {}
 
 
 def count_words(contents, summarizer=min):
@@ -159,11 +163,16 @@ def specified_entity_greater_than_count(
 ):
     """Determine if the entity count is greater than expected."""
     # count the fragments/regex in either a file in a directory or String contents
-    file_entity_count = count_entities(
+    file_entity_count, file_entity_count_dictionary = count_entities(
         chosen_fragment, checking_function, given_file, containing_directory, contents
     )
     # check the condition and also return file_entity_count
-    return util.greater_than_equal_exacted(file_entity_count, expected_count, exact)
+    condition_truth, value = util.greater_than_equal_exacted(
+        file_entity_count, expected_count, exact
+    )
+    # also return an empty dictionary since this function does not
+    # need to count details about multiple entities
+    return condition_truth, value, {}
 
 
 # pylint: disable=bad-continuation
@@ -190,7 +199,9 @@ def count_entities(
         # read the text from the file and the check for the chosen fragment
         file_contents = file_for_checking.read_text()
         file_contents_count = checking_function(file_contents, chosen_fragment)
-    return file_contents_count
+    # also return an empty dictionary since this function does not
+    # need to count details about multiple entities
+    return file_contents_count, {}
 
 
 # pylint: disable=bad-continuation

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -82,7 +82,7 @@ def invoke_all_comment_checks(
     if comment_type == constants.comments.Single_Line:
         # check comments in Java
         if language == constants.languages.Java:
-            met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,
@@ -91,7 +91,7 @@ def invoke_all_comment_checks(
             )
         # check comments in Python
         if language == constants.languages.Python:
-            met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,
@@ -102,7 +102,7 @@ def invoke_all_comment_checks(
     elif comment_type == constants.comments.Multiple_Line:
         # check comments in Java
         if language == constants.languages.Java:
-            met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,
@@ -111,7 +111,7 @@ def invoke_all_comment_checks(
             )
         # check comments in Python
         if language == constants.languages.Python:
-            met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,
@@ -158,7 +158,7 @@ def invoke_all_comment_checks(
 def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=False):
     """Perform the paragraph check and return the results."""
     met_or_exceeded_count = 0
-    met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+    met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
         filecheck, directory, expected_count, fragments.count_paragraphs, exact
     )
     # create the message and the diagnostic
@@ -197,7 +197,7 @@ def invoke_all_word_count_checks(
 ):
     """Perform the word count check and return the results."""
     met_or_exceeded_count = 0
-    met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+    met_or_exceeded_count, actual_count, actual_count_dictionary = entities.entity_greater_than_count(
         filecheck, directory, expected_count, count_function
     )
     # create the message and the diagnostic
@@ -238,6 +238,8 @@ def invoke_all_word_count_checks(
         + str(actual_count)
         + constants.markers.Space
         + conclusion.replace(constants.words.In_Every, constants.words.In_A)
+        + constants.markers.Space
+        + str(actual_count_dictionary)
     )
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count
@@ -282,7 +284,7 @@ def invoke_all_fragment_checks(
 ):
     """Perform the check for a fragment existence in file or contents and return the results."""
     met_or_exceeded_count = 0
-    met_or_exceeded_count, actual_count = fragments.specified_entity_greater_than_count(
+    met_or_exceeded_count, actual_count, actual_count_dictionary = fragments.specified_entity_greater_than_count(
         fragment,
         fragments.count_specified_fragment,
         expected_count,
@@ -366,7 +368,7 @@ def invoke_all_regex_checks(
 ):
     """Perform the check for a regex existence in file or contents and return the results."""
     met_or_exceeded_count = 0
-    met_or_exceeded_count, actual_count = fragments.specified_entity_greater_than_count(
+    met_or_exceeded_count, actual_count, actual_count_dictionary = fragments.specified_entity_greater_than_count(
         regex,
         fragments.count_specified_regex,
         expected_count,

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -228,18 +228,18 @@ def invoke_all_word_count_checks(
             + constants.markers.Space
             + conclusion
         )
-    # create a diagnostic message and report the result
-    # replace "in every" with "in a" since the diagnostic
-    # signals the fact that there was at least a single
-    # paragraph that had a word count below the standard
-    # set for all of the paragraphs in technical writing
+    # Create a diagnostic message and report the result
+    # replace "in every" with "in a" and a specific paragraph number.
+    # This diagnostic signals the fact that there was at least
+    # a single paragraph that had a word count below the standard
+    # set for all of the paragraphs in the technical writing
+    word_diagnostic = util.get_word_diagnostic(actual_count_dictionary)
     diagnostic = (
         "Found "
         + str(actual_count)
         + constants.markers.Space
-        + conclusion.replace(constants.words.In_Every, constants.words.In_A)
+        + conclusion.replace(constants.words.In_Every, word_diagnostic)
         + constants.markers.Space
-        + str(actual_count_dictionary)
     )
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -118,6 +118,14 @@ def invoke_all_comment_checks(
                 comments.count_multiline_python_comment,
                 exact,
             )
+    # check comments in a not-supported language
+    # currently the only valid options are:
+    # --> single-line
+    # --> multiple-line
+    # this means that this check will fail because
+    # it will not find any of the specified comments
+    else:
+        pass
     # create the message and the diagnostic
     if not exact:
         # create an "at least" message, which is the default

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -201,6 +201,9 @@ def invoke_all_word_count_checks(
         filecheck, directory, expected_count, count_function
     )
     # create the message and the diagnostic
+    # note that the conclusion variable is customized so that it
+    # displays the correct message and diagnostic based on whether
+    # the check was for a "total words" or a "minimum words" check
     if not exact:
         # create an "at least" message, which is the default
         message = (
@@ -226,8 +229,15 @@ def invoke_all_word_count_checks(
             + conclusion
         )
     # create a diagnostic message and report the result
+    # replace "in every" with "in a" since the diagnostic
+    # signals the fact that there was at least a single
+    # paragraph that had a word count below the standard
+    # set for all of the paragraphs in technical writing
     diagnostic = (
-        "Found " + str(actual_count) + " word(s) in a paragraph of the specified file"
+        "Found "
+        + str(actual_count)
+        + constants.markers.Space
+        + conclusion.replace(constants.words.In_Every, constants.words.In_A)
     )
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count

--- a/gator/util.py
+++ b/gator/util.py
@@ -6,6 +6,8 @@ from gator import files
 import json
 import os
 
+from num2words import num2words
+
 
 def verify_gatorgrader_home(current_gatorgrader_home):
     """Verify that the GATORGRADER_HOME variable is set correctly."""
@@ -88,3 +90,8 @@ def greater_than_equal_exacted(first, second, exact=False):
     if exact and first == second:
         return True, first
     return False, first
+
+
+def get_number_as_words(number, format=constants.words.Ordinal):
+    """Return a textual version of the provided word."""
+    return num2words(number, to=format)

--- a/gator/util.py
+++ b/gator/util.py
@@ -101,3 +101,20 @@ def greater_than_equal_exacted(first, second, exact=False):
 def get_number_as_words(number, format=constants.words.Ordinal):
     """Return a textual version of the provided word."""
     return num2words(number, to=format)
+
+
+def get_word_diagnostic(word_count_dictionary):
+    """Create a full diagnostic based on the dictionary of (paragraph, word counts)."""
+    # create a diagnostics like "in the third paragraph" based on the dictionary
+    # that contains the words counts in each of the paragraphs of a document
+    if word_count_dictionary:
+        paragraph_number_details = get_first_minimum_value(word_count_dictionary)
+        paragraph_number = paragraph_number_details[0]
+        paragraph_number_as_word = get_number_as_words(paragraph_number)
+        paragraph_number_as_word_phrase = (
+            constants.words.In_The + constants.markers.Space + paragraph_number_as_word
+        )
+        return paragraph_number_as_word_phrase
+    # since there are no paragraphs and no counts of words because the dictionary
+    # is empty, return the empty string instead of a diagnostic phrase
+    return constants.markers.Nothing

--- a/gator/util.py
+++ b/gator/util.py
@@ -3,6 +3,9 @@
 from gator import constants
 from gator import files
 
+from itertools import groupby
+from operator import itemgetter
+
 import json
 import os
 
@@ -53,6 +56,23 @@ def get_symbol_answer(boolean_value):
     if boolean_value is True:
         return "✔"
     return "✘"
+
+
+def get_first_value(input_dictionary, finder=min):
+    """Return the values matched by a finder function."""
+    # pick the key and value that is matched by the finder
+    # note that the  return is in the format (key, value)
+    return finder(input_dictionary.items(), key=lambda input_dictionary: input_dictionary[1])
+
+
+def get_first_maximum_value(input_dictionary):
+    """Return the first maximum value."""
+    return get_first_value(input_dictionary, max)
+
+
+def get_first_minimum_value(input_dictionary):
+    """Return the first minimum value."""
+    return get_first_value(input_dictionary, min)
 
 
 def is_json(potential_json):

--- a/gator/util.py
+++ b/gator/util.py
@@ -65,7 +65,7 @@ def is_json(potential_json):
 
 
 def greater_than_equal_exacted(first, second, exact=False):
-    """Return True if first >= second unless exact, then True if ==, otherwise False"""
+    """Return True if first >= second unless exact, then True if ==, otherwise False."""
     if not exact and first >= second:
         return True, first
     if exact and first == second:

--- a/gator/util.py
+++ b/gator/util.py
@@ -3,9 +3,6 @@
 from gator import constants
 from gator import files
 
-from itertools import groupby
-from operator import itemgetter
-
 import json
 import os
 

--- a/gator/util.py
+++ b/gator/util.py
@@ -60,8 +60,14 @@ def get_symbol_answer(boolean_value):
 def get_first_value(input_dictionary, finder=min):
     """Return the values matched by a finder function."""
     # pick the key and value that is matched by the finder
-    # note that the  return is in the format (key, value)
-    return finder(input_dictionary.items(), key=lambda input_dictionary: input_dictionary[1])
+    # note that the return is in the format (key, value)
+    # the dictionary is empty, so return None for the key and value
+    if not input_dictionary:
+        return (None, None)
+    # the dictionary is not empty, so return the located (key, value)
+    return finder(
+        input_dictionary.items(), key=lambda input_dictionary: input_dictionary[1]
+    )
 
 
 def get_first_maximum_value(input_dictionary):

--- a/gator/util.py
+++ b/gator/util.py
@@ -65,7 +65,7 @@ def is_json(potential_json):
 
 
 def greater_than_equal_exacted(first, second, exact=False):
-    """Return True if first >= second unless exact, then True if ==, otherwise False."""
+    """Return True if first >= second unless exact, then True if ==, otherwise False"""
     if not exact and first >= second:
         return True, first
     if exact and first == second:

--- a/scripts/cover.bat
+++ b/scripts/cover.bat
@@ -1,4 +1,4 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-pipenv run pytest -s --cov-config .coveragerc --cov-report term-missing --cov-report xml --cov
+pipenv run pytest -s --cov-config .coveragerc --cov-report term-missing --cov-report xml --cov --cov-branch

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pipenv run pytest -s --cov-config .coveragerc --cov-report term-missing --cov-report xml --cov
+pipenv run pytest -s --cov-config .coveragerc --cov-report term-missing --cov-report xml --cov --cov-branch

--- a/scripts/lint.bat
+++ b/scripts/lint.bat
@@ -16,37 +16,37 @@ del .xyzfiles
 echo -- Running black
 pipenv run black %CHECK% %FILES%
 if ERRORLEVEL 1 (
-	echo -- Failed
-	set PASSED=false
+    echo -- Failed
+    set PASSED=false
 ) else (
-	echo -- Passed
+    echo -- Passed
 )
 
 echo -- Running pylint
 pipenv run pylint %FILES%
 if ERRORLEVEL 1 (
-	echo -- Failed
-	set PASSED=false
+    echo -- Failed
+    set PASSED=false
 ) else (
-	echo -- Passed
+    echo -- Passed
 )
 
 echo -- Running flake8
 pipenv run flake8 %FILES%
 if ERRORLEVEL 1 (
-	echo -- Failed
-	set PASSED=false
+    echo -- Failed
+    set PASSED=false
 ) else (
-	echo -- Passed
+    echo -- Passed
 )
 
 echo -- Running bandit
 pipenv run bandit -c bandit.yml %FILES%
 if ERRORLEVEL 1 (
-	echo -- Failed
-	set PASSED=false
+    echo -- Failed
+    set PASSED=false
 ) else (
-	echo -- Passed
+    echo -- Passed
 )
 
 if "%PASSED%"=="true" (

--- a/scripts/lint.bat
+++ b/scripts/lint.bat
@@ -49,6 +49,15 @@ if ERRORLEVEL 1 (
     echo -- Passed
 )
 
+echo -- Running pydocstyle
+pipenv run pydocstyle %FILES%
+if ERRORLEVEL 1 (
+    echo -- Failed
+    set PASSED=false
+) else (
+    echo -- Passed
+)
+
 if "%PASSED%"=="true" (
     exit /b 0
 ) else (

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -592,6 +592,34 @@ def test_is_not_valid_exists(chosen_arguments):
 @pytest.mark.parametrize(
     "chosen_arguments",
     [
+        (["--nowelcome", "--command", "C", "--executes"]),
+        (["--command", "C", "--executes"]),
+    ],
+)
+def test_is_valid_executes(chosen_arguments):
+    """Check that valid argument combinations do verify correctly."""
+    parsed_arguments = arguments.parse(chosen_arguments)
+    verified_arguments = arguments.is_valid_executes(parsed_arguments)
+    assert verified_arguments is True
+
+
+@pytest.mark.parametrize(
+    "chosen_arguments",
+    [
+        (["--nowelcome", "--file", "f", "--executes"]),
+        (["--file", "f", "--executes"]),
+    ],
+)
+def test_is_not_valid_executes(chosen_arguments):
+    """Check that valid argument combinations do verify correctly."""
+    parsed_arguments = arguments.parse(chosen_arguments)
+    verified_arguments = arguments.is_valid_executes(parsed_arguments)
+    assert verified_arguments is False
+
+
+@pytest.mark.parametrize(
+    "chosen_arguments",
+    [
         (
             [
                 "--nowelcome",

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -605,10 +605,7 @@ def test_is_valid_executes(chosen_arguments):
 
 @pytest.mark.parametrize(
     "chosen_arguments",
-    [
-        (["--nowelcome", "--file", "f", "--executes"]),
-        (["--file", "f", "--executes"]),
-    ],
+    [(["--nowelcome", "--file", "f", "--executes"]), (["--file", "f", "--executes"])],
 )
 def test_is_not_valid_executes(chosen_arguments):
     """Check that valid argument combinations do verify correctly."""

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -503,6 +503,17 @@ def test_exact_count_check_not_valid(chosen_arguments):
     assert verified_arguments is False
 
 
+@pytest.mark.parametrize(
+    "chosen_arguments",
+    [(["--nowelcome", "--directory", "D", "--file", "f", "--words", "50"])],
+)
+def test_exact_count_check_is_not_valid_cover_branch(chosen_arguments):
+    """Check that invalid argument combinations do not verify correctly."""
+    parsed_arguments = arguments.parse(chosen_arguments)
+    verified_arguments = arguments.is_valid_exact(parsed_arguments)
+    assert verified_arguments is False
+
+
 # }}}
 
 # Region: Verified Arguments Tests for helper functions {{{

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -560,6 +560,38 @@ def test_is_valid_comments_valid(chosen_arguments):
 @pytest.mark.parametrize(
     "chosen_arguments",
     [
+        (["--nowelcome", "--directory", "D", "--file", "f", "--exists"]),
+        (["--nowelcome", "--file", "f", "--directory", "D", "--exists"]),
+        (["--file", "f", "--directory", "D", "--exists"]),
+        (["--directory", "D", "--file", "F", "--exists"]),
+    ],
+)
+def test_is_valid_exists(chosen_arguments):
+    """Check that valid argument combinations do verify correctly."""
+    parsed_arguments = arguments.parse(chosen_arguments)
+    verified_arguments = arguments.is_valid_exists(parsed_arguments)
+    assert verified_arguments is True
+
+
+@pytest.mark.parametrize(
+    "chosen_arguments",
+    [
+        (["--nowelcome", "--file", "f", "--exists"]),
+        (["--nowelcome", "--directory", "D", "--exists"]),
+        (["--file", "f", "--exists"]),
+        (["--directory", "D", "--exists"]),
+    ],
+)
+def test_is_not_valid_exists(chosen_arguments):
+    """Check that valid argument combinations do not verify correctly."""
+    parsed_arguments = arguments.parse(chosen_arguments)
+    verified_arguments = arguments.is_valid_exists(parsed_arguments)
+    assert verified_arguments is False
+
+
+@pytest.mark.parametrize(
+    "chosen_arguments",
+    [
         (
             [
                 "--nowelcome",

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -12,7 +12,7 @@ def test_file_contains_singleline_java_comment_count(tmpdir):
     hello_file.write("//// hello world")
     assert hello_file.read() == "//// hello world"
     assert len(tmpdir.listdir()) == 1
-    comment_count = entities.count_entities(
+    comment_count, _ = entities.count_entities(
         hello_file.basename, hello_file.dirname, comments.count_singleline_java_comment
     )
     assert comment_count == 1
@@ -24,20 +24,20 @@ def test_file_contains_multiline_java_comment_count(tmpdir):
     hello_file.write("/* hello world */")
     assert hello_file.read() == "/* hello world */"
     assert len(tmpdir.listdir()) == 1
-    comment_count = entities.count_entities(
+    comment_count, _ = entities.count_entities(
         hello_file.basename, hello_file.dirname, comments.count_multiline_java_comment
     )
     assert comment_count == 1
 
 
 def test_file_contains_multiline_python_comment_count(tmpdir):
-    """Check that the multiline python comment count works."""
+    """Check that the multiline Python comment count works."""
     hello_file = tmpdir.mkdir("subdirectory").join("Hello.py")
     string = "Hello \n World"
     hello_file.write('"""{}"""'.format(string))
     assert hello_file.read() == '"""Hello \n World"""'
     assert len(tmpdir.listdir()) == 1
-    comment_count = entities.count_entities(
+    comment_count, _ = entities.count_entities(
         hello_file.basename, hello_file.dirname, comments.count_multiline_python_comment
     )
     assert comment_count == 1
@@ -49,7 +49,7 @@ def test_file_contains_singleline_java_comment_greater(tmpdir):
     hello_file.write("//// hello world")
     assert hello_file.read() == "//// hello world"
     assert len(tmpdir.listdir()) == 1
-    greater_than_count, _ = entities.entity_greater_than_count(
+    greater_than_count, _, _ = entities.entity_greater_than_count(
         hello_file.basename,
         hello_file.dirname,
         1,
@@ -64,7 +64,7 @@ def test_file_contains_multiline_java_comment_greater(tmpdir):
     hello_file.write("/* hello world */")
     assert hello_file.read() == "/* hello world */"
     assert len(tmpdir.listdir()) == 1
-    greater_than_count, _ = entities.entity_greater_than_count(
+    greater_than_count, _, _ = entities.entity_greater_than_count(
         hello_file.basename,
         hello_file.dirname,
         1,
@@ -80,7 +80,7 @@ def test_file_contains_multiline_python_comment_greater(tmpdir):
     hello_file.write('"""{}"""'.format(string))
     assert hello_file.read() == '"""Hello \n World"""'
     assert len(tmpdir.listdir()) == 1
-    greater_than_count, _ = entities.entity_greater_than_count(
+    greater_than_count, _, _ = entities.entity_greater_than_count(
         hello_file.basename,
         hello_file.dirname,
         1,
@@ -95,7 +95,7 @@ def test_file_contains_singleline_java_comment_not_greater(tmpdir):
     hello_file.write("/ hello world")
     assert hello_file.read() == "/ hello world"
     assert len(tmpdir.listdir()) == 1
-    greater_than_count, _ = entities.entity_greater_than_count(
+    greater_than_count, _, _ = entities.entity_greater_than_count(
         hello_file.basename,
         hello_file.dirname,
         1,
@@ -110,7 +110,7 @@ def test_file_contains_multiline_java_comment_not_greater(tmpdir):
     hello_file.write("/* hello world")
     assert hello_file.read() == "/* hello world"
     assert len(tmpdir.listdir()) == 1
-    greater_than_count, _ = entities.entity_greater_than_count(
+    greater_than_count, _, _ = entities.entity_greater_than_count(
         hello_file.basename,
         hello_file.dirname,
         1,
@@ -126,7 +126,7 @@ def test_file_contains_multiline_python_comment_not_greater(tmpdir):
     hello_file.write('"""{}'.format(string))
     assert hello_file.read() == '"""Hello \n World'
     assert len(tmpdir.listdir()) == 1
-    greater_than_count, _ = entities.entity_greater_than_count(
+    greater_than_count, _, _ = entities.entity_greater_than_count(
         hello_file.basename,
         hello_file.dirname,
         1,
@@ -159,7 +159,10 @@ def test_file_contains_multiline_python_comment_not_greater(tmpdir):
 )
 def test_singleline_java_comments_zero_or_one(code_string, expected_count):
     """Check that it finds zero or one single-line comments."""
-    assert comments.count_singleline_java_comment(code_string) == expected_count
+    count_of_singleline_java_comments, _ = comments.count_singleline_java_comment(
+        code_string
+    )
+    assert count_of_singleline_java_comments == expected_count
 
 
 @pytest.mark.parametrize(
@@ -186,7 +189,11 @@ def test_singleline_java_comments_zero_or_one(code_string, expected_count):
 )
 def test_singleline_python_comments_zero_or_one(code_string, expected_count):
     """Check that it finds zero or one Python comments."""
-    assert comments.count_singleline_python_comment(code_string) == expected_count
+    count_of_singleline_python_comments, _ = comments.count_singleline_python_comment(
+        code_string
+    )
+    assert count_of_singleline_python_comments == expected_count
+    # assert comments.count_singleline_python_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -211,7 +218,11 @@ def test_singleline_python_comments_zero_or_one(code_string, expected_count):
 )
 def test_singleline_java_comments_many(code_string, expected_count):
     """Check that it finds many singleline comments."""
-    assert comments.count_singleline_java_comment(code_string) == expected_count
+    count_of_singleline_java_comments, _ = comments.count_singleline_java_comment(
+        code_string
+    )
+    assert count_of_singleline_java_comments == expected_count
+    # assert comments.count_singleline_java_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -235,8 +246,12 @@ def test_singleline_java_comments_many(code_string, expected_count):
     ],
 )
 def test_singleline_python_comments_many(code_string, expected_count):
-    """Check that it finds many singleline comments."""
-    assert comments.count_singleline_python_comment(code_string) == expected_count
+    """Check that it finds many Python singleline comments."""
+    count_of_singleline_python_comments, _ = comments.count_singleline_python_comment(
+        code_string
+    )
+    assert count_of_singleline_python_comments == expected_count
+    # assert comments.count_singleline_python_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -250,7 +265,11 @@ def test_singleline_python_comments_many(code_string, expected_count):
 )
 def test_singleline_java_comments_mixed(code_string, expected_count):
     """Check that it can find singleline comments in mixtures."""
-    assert comments.count_singleline_java_comment(code_string) == expected_count
+    count_of_singleline_java_comments, _ = comments.count_singleline_java_comment(
+        code_string
+    )
+    assert count_of_singleline_java_comments == expected_count
+    # assert comments.count_singleline_java_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -265,8 +284,12 @@ def test_singleline_java_comments_mixed(code_string, expected_count):
     ],
 )
 def test_singleline_python_comments_mixed(code_string, expected_count):
-    """Check that it can find multiline comments in mixtures."""
-    assert comments.count_singleline_python_comment(code_string) == expected_count
+    """Check that it can find singleline Python comments in mixtures."""
+    count_of_singleline_python_comments, _ = comments.count_singleline_python_comment(
+        code_string
+    )
+    assert count_of_singleline_python_comments == expected_count
+    # assert comments.count_singleline_python_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -296,7 +319,11 @@ def test_singleline_python_comments_mixed(code_string, expected_count):
 )
 def test_multiline_java_comments_zero_or_one(code_string, expected_count):
     """Check that it finds zero or one multiline comments."""
-    assert comments.count_multiline_java_comment(code_string) == expected_count
+    count_of_multiline_java_comments, _ = comments.count_multiline_java_comment(
+        code_string
+    )
+    assert count_of_multiline_java_comments == expected_count
+    # assert comments.count_multiline_java_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -325,8 +352,12 @@ def test_multiline_java_comments_zero_or_one(code_string, expected_count):
     ],
 )
 def test_multiline_python_comments_zero_or_one(code_string, expected_count):
-    """Check that it finds zero or one multiline comments."""
-    assert comments.count_multiline_python_comment(code_string) == expected_count
+    """Check that it finds zero or one Python multiline comments."""
+    count_of_multiline_python_comments, _ = comments.count_multiline_python_comment(
+        code_string
+    )
+    assert count_of_multiline_python_comments == expected_count
+    # assert comments.count_multiline_python_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -342,8 +373,12 @@ def test_multiline_python_comments_zero_or_one(code_string, expected_count):
     ],
 )
 def test_multiline_java_comments_two(code_string, expected_count):
-    """Check that it has two or more multiline python comments."""
-    assert comments.count_multiline_java_comment(code_string) == expected_count
+    """Check that it has two or more multiline Java comments."""
+    count_of_multiline_java_comments, _ = comments.count_multiline_java_comment(
+        code_string
+    )
+    assert count_of_multiline_java_comments == expected_count
+    # assert comments.count_multiline_java_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -360,7 +395,11 @@ def test_multiline_java_comments_two(code_string, expected_count):
 )
 def test_multiline_python_comments_two(code_string, expected_count):
     """Check that it has two or more multiline python comments."""
-    assert comments.count_multiline_python_comment(code_string) == expected_count
+    count_of_multiline_python_comments, _ = comments.count_multiline_python_comment(
+        code_string
+    )
+    assert count_of_multiline_python_comments == expected_count
+    # assert comments.count_multiline_python_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -375,7 +414,11 @@ def test_multiline_python_comments_two(code_string, expected_count):
 )
 def test_multiline_java_comments_mixed(code_string, expected_count):
     """Check that it can find multiline comments in mixtures."""
-    assert comments.count_multiline_java_comment(code_string) == expected_count
+    count_of_multiline_java_comments, _ = comments.count_multiline_java_comment(
+        code_string
+    )
+    assert count_of_multiline_java_comments == expected_count
+    # assert comments.count_multiline_java_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -390,8 +433,12 @@ def test_multiline_java_comments_mixed(code_string, expected_count):
     ],
 )
 def test_multiline_python_comments_mixed(code_string, expected_count):
-    """Check that it can find multiline comments in mixtures."""
-    assert comments.count_multiline_python_comment(code_string) == expected_count
+    """Check that it can find multiline Python comments in mixtures."""
+    count_of_multiline_python_comments, _ = comments.count_multiline_python_comment(
+        code_string
+    )
+    assert count_of_multiline_python_comments == expected_count
+    # assert comments.count_multiline_python_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -406,8 +453,12 @@ def test_multiline_python_comments_mixed(code_string, expected_count):
     ],
 )
 def test_multiline_java_comments_many(code_string, expected_count):
-    """Check that it finds many multiline python docstring comments."""
-    assert comments.count_multiline_java_comment(code_string) == expected_count
+    """Check that it finds many multiline Python docstring comments."""
+    count_of_multiline_java_comments, _ = comments.count_multiline_java_comment(
+        code_string
+    )
+    assert count_of_multiline_java_comments == expected_count
+    # assert comments.count_multiline_java_comment(code_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -422,5 +473,9 @@ def test_multiline_java_comments_many(code_string, expected_count):
     ],
 )
 def test_multiline_python_comments_many(code_string, expected_count):
-    """Check that it finds many multiline python docstring comments."""
-    assert comments.count_multiline_python_comment(code_string) == expected_count
+    """Check that it finds many multiline Python docstring comments."""
+    count_of_multiline_python_comments, _ = comments.count_multiline_python_comment(
+        code_string
+    )
+    assert count_of_multiline_python_comments == expected_count
+    # assert comments.count_multiline_python_comment(code_string) == expected_count

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -82,6 +82,8 @@ def test_words_constant_defined():
     assert constants.words.Total == "word(s) in total"
     assert constants.words.In_A == "in a"
     assert constants.words.In_Every == "in every"
+    assert constants.words.Cardinal == "cardinal"
+    assert constants.words.Ordinal == "ordinal"
 
 
 def test_environmentvariables_constant_defined():
@@ -194,7 +196,9 @@ def test_words_constant_cannot_redefine():
         constants.words.Minimum = CANNOT_SET_CONSTANT_VARIABLE
         constants.words.Total = CANNOT_SET_CONSTANT_VARIABLE
         constants.words.In_A = CANNOT_SET_CONSTANT_VARIABLE
-        constants.words.In_Even = CANNOT_SET_CONSTANT_VARIABLE
+        constants.words.In_Every = CANNOT_SET_CONSTANT_VARIABLE
+        constants.words.Cardinal = CANNOT_SET_CONSTANT_VARIABLE
+        constants.words.Ordinal = CANNOT_SET_CONSTANT_VARIABLE
 
 
 def test_environmentvariables_constant_cannot_redefine():

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -82,8 +82,10 @@ def test_words_constant_defined():
     assert constants.words.Total == "word(s) in total"
     assert constants.words.In_A == "in a"
     assert constants.words.In_Every == "in every"
+    assert constants.words.In_The == "in the"
     assert constants.words.Cardinal == "cardinal"
     assert constants.words.Ordinal == "ordinal"
+    assert constants.words.Paragraph == "paragraph"
 
 
 def test_environmentvariables_constant_defined():
@@ -197,8 +199,10 @@ def test_words_constant_cannot_redefine():
         constants.words.Total = CANNOT_SET_CONSTANT_VARIABLE
         constants.words.In_A = CANNOT_SET_CONSTANT_VARIABLE
         constants.words.In_Every = CANNOT_SET_CONSTANT_VARIABLE
+        constants.words.In_The = CANNOT_SET_CONSTANT_VARIABLE
         constants.words.Cardinal = CANNOT_SET_CONSTANT_VARIABLE
         constants.words.Ordinal = CANNOT_SET_CONSTANT_VARIABLE
+        constants.words.Paragraph = CANNOT_SET_CONSTANT_VARIABLE
 
 
 def test_environmentvariables_constant_cannot_redefine():

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -40,6 +40,7 @@ def test_codes_constant_defined():
     """Check correctness for the variables in the codes constant."""
     assert constants.codes.Error == 1
     assert constants.codes.Success == 0
+    assert constants.codes.No_Words == 0
 
 
 def test_arguments_constant_defined():
@@ -138,6 +139,8 @@ def test_codes_constant_cannot_redefine():
         constants.codes.Success = 10
     with pytest.raises(AttributeError):
         constants.codes.Error = 10
+    with pytest.raises(AttributeError):
+        constants.codes.No_Words = 10
 
 
 def test_arguments_constant_cannot_redefine():

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -78,6 +78,8 @@ def test_words_constant_defined():
     """Check correctness for the variables in the versioncontrol constant."""
     assert constants.words.Minimum == "word(s) in every paragraph"
     assert constants.words.Total == "word(s) in total"
+    assert constants.words.In_A == "in a"
+    assert constants.words.In_Every == "in every"
 
 
 def test_environmentvariables_constant_defined():
@@ -186,6 +188,8 @@ def test_words_constant_cannot_redefine():
     with pytest.raises(AttributeError):
         constants.words.Minimum = CANNOT_SET_CONSTANT_VARIABLE
         constants.words.Total = CANNOT_SET_CONSTANT_VARIABLE
+        constants.words.In_A = CANNOT_SET_CONSTANT_VARIABLE
+        constants.words.In_Even = CANNOT_SET_CONSTANT_VARIABLE
 
 
 def test_environmentvariables_constant_cannot_redefine():

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -195,7 +195,8 @@ def test_words_different_min_counts(writing_string, expected_count, expected_par
 def test_minimum_words_different_min_counts(writing_string, expected_count):
     """Check that it can detect different counts of words."""
     # only check the minimum count
-    assert fragments.count_minimum_words(writing_string) == expected_count
+    actual_count, actual_count_dictionary = fragments.count_minimum_words(writing_string)
+    assert actual_count == expected_count
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -670,12 +670,12 @@ def test_chosen_regex_zero_or_one(writing_string, chosen_regex, expected_count):
             3,
         ),
         (
-            "<footer>happyness</footer> <footer>everything</footer>",
+            "<footer>happiness</footer> <footer>everything</footer>",
             r"<footer>(.*?)<\/footer>",
             2,
         ),
         (
-            "<footer>happyness</footer> <footer>everything</footer>",
+            "<footer>happiness</footer> <footer>everything</footer>",
             r"<footer>(.*)<\/footer>",
             1,
         ),

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -261,7 +261,8 @@ def test_minimum_words_different_min_counts(writing_string, expected_count):
 def test_total_words_different_sum_counts(writing_string, expected_count):
     """Check that it can detect different counts of total words."""
     # only check the sum count
-    assert fragments.count_total_words(writing_string) == expected_count
+    actual_count, actual_count_dictionary = fragments.count_total_words(writing_string)
+    assert actual_count == expected_count
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -34,7 +34,9 @@ from gator import fragments
 )
 def test_paragraphs_zero_or_one(writing_string, expected_count):
     """Check that it can detect zero or one paragraphs."""
-    assert fragments.count_paragraphs(writing_string) == expected_count
+    actual_paragraph_count, _ = fragments.count_paragraphs(writing_string)
+    assert actual_paragraph_count == expected_count
+    # assert fragments.count_paragraphs(writing_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -58,7 +60,9 @@ def test_paragraphs_zero_or_one(writing_string, expected_count):
 )
 def test_paragraphs_many(writing_string, expected_count):
     """Check that it can detect two or more paragraphs."""
-    assert fragments.count_paragraphs(writing_string) == expected_count
+    actual_paragraph_count, _ = fragments.count_paragraphs(writing_string)
+    assert actual_paragraph_count == expected_count
+    # assert fragments.count_paragraphs(writing_string) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -74,42 +78,49 @@ def test_paragraphs_many(writing_string, expected_count):
         (
             "The method test.main was called. Hello world! Writing a lot.\n\n"
             "New one. Question? Fun!",
-            4, 2
+            4,
+            2,
         ),
         (
             "New one. Question? Fun! Nice!\n\n"
             "The method test.main was called. Hello world! Writing a lot.",
-            5, 2
+            5,
+            2,
         ),
         (
             "The method `test.main` was called. Hello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
-            5, 2
+            5,
+            2,
         ),
         (
             "The method test.main was called.\nHello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
-            5, 2
+            5,
+            2,
         ),
         # code blocks
         (
             "Here is some code in a code block.\n\n```\ndef test_function():\n    "
             "function_call()\n```\n\nHello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
-            4, 3
+            4,
+            3,
         ),
         (
             "Here is some code in an inline code block: `def test_function():`. "
             "Hello world! Example? Writing.\n\n"
             "New one. `Code?` Question? Fun! Nice!",
-            6, 2
+            6,
+            2,
         ),
         # images
         (
             "Here is some code in an inline code block: `def test_function():`. "
             "Hello world! Example? Writing.\n\n"
             "New one. [Image](https://example.com/image.png) Question? Fun! Nice!",
-            6, 2
+            6,
+            2,
         ),
         # links
         ("[This link is five words](www.url.com)", 5, 1),
@@ -120,7 +131,9 @@ def test_paragraphs_many(writing_string, expected_count):
         ("One sentence's\ngreat delusion.", 4, 1),
     ],
 )
-def test_words_different_min_counts(writing_string, expected_count, expected_paragraph_count):
+def test_words_different_min_counts(
+    writing_string, expected_count, expected_paragraph_count
+):
     """Check that it can detect different counts of words."""
     # check the summarized value and the size of the dictionary
     # --> implicit use of the min function, which is the default
@@ -195,7 +208,9 @@ def test_words_different_min_counts(writing_string, expected_count, expected_par
 def test_minimum_words_different_min_counts(writing_string, expected_count):
     """Check that it can detect different counts of words."""
     # only check the minimum count
-    actual_count, actual_count_dictionary = fragments.count_minimum_words(writing_string)
+    actual_count, actual_count_dictionary = fragments.count_minimum_words(
+        writing_string
+    )
     assert actual_count == expected_count
 
 
@@ -394,15 +409,15 @@ def test_count_entities_from_file(tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         "hello", fragments.count_specified_fragment, hello_file, directory, ""
     )
     assert count == 1
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         "world", fragments.count_specified_fragment, hello_file, directory, ""
     )
     assert count == 1
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         "planet", fragments.count_specified_fragment, hello_file, directory, ""
     )
     assert count == 0
@@ -411,15 +426,15 @@ def test_count_entities_from_file(tmpdir):
 def test_count_entities_from_contents():
     """Check that counting fragments in a string works correctly."""
     value = "/* hello world */"
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         "hello", fragments.count_specified_fragment, contents=value
     )
     assert count == 1
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         "world", fragments.count_specified_fragment, contents=value
     )
     assert count == 1
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         "planet", fragments.count_specified_fragment, contents=value
     )
     assert count == 0
@@ -433,12 +448,12 @@ def test_count_entities_from_file_with_threshold(tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         "hello", fragments.count_specified_fragment, 10, hello_file, directory, ""
     )
     assert actual_count == 1
     assert exceeds_threshold is False
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         "hello", fragments.count_specified_fragment, 1, hello_file, directory, ""
     )
     assert actual_count == 1
@@ -448,12 +463,12 @@ def test_count_entities_from_file_with_threshold(tmpdir):
 def test_count_entities_from_contents_with_threshold():
     """Check that counting fragments with threshold in a string works correctly."""
     value = "/* hello world */"
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         "hello", fragments.count_specified_fragment, 10, contents=value
     )
     assert actual_count == 1
     assert exceeds_threshold is False
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         "hello", fragments.count_specified_fragment, 1, contents=value
     )
     assert actual_count == 1
@@ -707,15 +722,15 @@ def test_count_regex_from_file(tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         r"\\begin(.*?)\\end", fragments.count_specified_regex, hello_file, directory
     )
     assert count == 1
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         r"planet", fragments.count_specified_regex, hello_file, directory, ""
     )
     assert count == 0
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         r"invalid[^]", fragments.count_specified_regex, hello_file, directory, ""
     )
     assert count == -1
@@ -724,15 +739,15 @@ def test_count_regex_from_file(tmpdir):
 def test_count_regex_from_contents():
     """Check that counting regex in a string works correctly."""
     value = "\\begin{document} hello! \\end{document}"
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         r"\\begin(.*?)\\end", fragments.count_specified_regex, contents=value
     )
     assert count == 1
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         r"planet", fragments.count_specified_regex, contents=value
     )
     assert count == 0
-    count = fragments.count_entities(
+    count, _ = fragments.count_entities(
         r"invalid[^]", fragments.count_specified_regex, contents=value
     )
     assert count == -1
@@ -746,17 +761,17 @@ def test_count_regex_from_file_with_threshold(tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         r"\\begin(.*?)\\end", fragments.count_specified_regex, 2, hello_file, directory
     )
     assert actual_count == 1
     assert exceeds_threshold is False
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         r"\\begin(.*?)\\end", fragments.count_specified_regex, 1, hello_file, directory
     )
     assert actual_count == 1
     assert exceeds_threshold is True
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         r"invalid[^]", fragments.count_specified_regex, 0, hello_file, directory
     )
 
@@ -767,17 +782,17 @@ def test_count_regex_from_file_with_threshold(tmpdir):
 def test_count_regex_from_contents_with_threshold():
     """Check that counting regex with threshold in a string works correctly."""
     value = "\\begin{document} hello! \\end{document}"
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         r"\\begin(.*?)\\end", fragments.count_specified_regex, 10, contents=value
     )
     assert actual_count == 1
     assert exceeds_threshold is False
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         r"\\begin(.*?)\\end", fragments.count_specified_regex, 1, contents=value
     )
     assert actual_count == 1
     assert exceeds_threshold is True
-    exceeds_threshold, actual_count = fragments.specified_entity_greater_than_count(
+    exceeds_threshold, actual_count, _ = fragments.specified_entity_greater_than_count(
         r"invalid[^]", fragments.count_specified_regex, 0, contents=value
     )
     assert actual_count == -1

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -62,70 +62,74 @@ def test_paragraphs_many(writing_string, expected_count):
 
 
 @pytest.mark.parametrize(
-    "writing_string,expected_count",
+    "writing_string,expected_count, expected_paragraph_count",
     [
-        ("", 0),
-        ("hello world! Writing a lot.\n\nsingle.", 1),
-        ("hello world! Writing a lot.\n\nnew one.", 2),
-        ("hello world! Writing a lot.\n\nNew one. Question?", 3),
-        ("This should be `five` words", 5),
-        ("This should still be `six` word's", 6),
-        ("The command `pipenv run pytest` should test", 7),
+        ("", 0, 0),
+        ("hello world! Writing a lot.\n\nsingle.", 1, 2),
+        ("hello world! Writing a lot.\n\nnew one.", 2, 2),
+        ("hello world! Writing a lot.\n\nNew one. Question?", 3, 2),
+        ("This should be `five` words", 5, 1),
+        ("This should still be `six` word's", 6, 1),
+        ("The command `pipenv run pytest` should test", 7, 1),
         (
             "The method test.main was called. Hello world! Writing a lot.\n\n"
             "New one. Question? Fun!",
-            4,
+            4, 2
         ),
         (
             "New one. Question? Fun! Nice!\n\n"
             "The method test.main was called. Hello world! Writing a lot.",
-            5,
+            5, 2
         ),
         (
             "The method `test.main` was called. Hello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
-            5,
+            5, 2
         ),
         (
             "The method test.main was called.\nHello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
-            5,
+            5, 2
         ),
         # code blocks
         (
             "Here is some code in a code block.\n\n```\ndef test_function():\n    "
             "function_call()\n```\n\nHello world! Example? Writing.\n\n"
             "New one. Question? Fun! Nice!",
-            4,
+            4, 3
         ),
         (
             "Here is some code in an inline code block: `def test_function():`. "
             "Hello world! Example? Writing.\n\n"
             "New one. `Code?` Question? Fun! Nice!",
-            6,
+            6, 2
         ),
         # images
         (
             "Here is some code in an inline code block: `def test_function():`. "
             "Hello world! Example? Writing.\n\n"
             "New one. [Image](https://example.com/image.png) Question? Fun! Nice!",
-            6,
+            6, 2
         ),
         # links
-        ("[This link is five words](www.url.com)", 5),
+        ("[This link is five words](www.url.com)", 5, 1),
         # emoji
-        (":thumbsup: is an emoji", 4),
+        (":thumbsup: is an emoji", 4, 1),
         # new lines
-        ("One sentence is\nanother's problem.", 5),
-        ("One sentence's\ngreat delusion.", 4),
+        ("One sentence is\nanother's problem.", 5, 1),
+        ("One sentence's\ngreat delusion.", 4, 1),
     ],
 )
-def test_words_different_min_counts(writing_string, expected_count):
+def test_words_different_min_counts(writing_string, expected_count, expected_paragraph_count):
     """Check that it can detect different counts of words."""
     # only check the minimum count
     # note that the default summarization function in a minimum
-    assert fragments.count_words(writing_string) == expected_count
-    assert fragments.count_words(writing_string, min) == expected_count
+    actual_count, actual_count_dictionary = fragments.count_words(writing_string)
+    assert actual_count == expected_count
+    assert len(actual_count_dictionary) == expected_paragraph_count
+    actual_count, actual_count_dictionary = fragments.count_words(writing_string, min)
+    assert len(actual_count_dictionary) == expected_paragraph_count
+    assert actual_count == expected_count
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -122,11 +122,12 @@ def test_paragraphs_many(writing_string, expected_count):
 )
 def test_words_different_min_counts(writing_string, expected_count, expected_paragraph_count):
     """Check that it can detect different counts of words."""
-    # only check the minimum count
-    # note that the default summarization function in a minimum
+    # check the summarized value and the size of the dictionary
+    # --> implicit use of the min function, which is the default
     actual_count, actual_count_dictionary = fragments.count_words(writing_string)
     assert actual_count == expected_count
     assert len(actual_count_dictionary) == expected_paragraph_count
+    # --> explicit use of the min function, which is now a parameter
     actual_count, actual_count_dictionary = fragments.count_words(writing_string, min)
     assert len(actual_count_dictionary) == expected_paragraph_count
     assert actual_count == expected_count

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -325,7 +325,10 @@ def test_total_words_different_sum_counts(writing_string, expected_count):
 def test_words_different_sum_counts(writing_string, expected_count):
     """Check that it can detect different counts of total words."""
     # only check the sum count
-    assert fragments.count_words(writing_string, sum) == expected_count
+    # does not check size of dictionary as that was
+    # checked in a previous parameterized test case
+    actual_count, actual_count_dictionary = fragments.count_words(writing_string, sum)
+    assert actual_count == expected_count
 
 
 @pytest.mark.parametrize(

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -464,6 +464,29 @@ def test_comment_counts_check_multiple_java(reset_results_dictionary, tmpdir):
 
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
+def test_comment_counts_check_multiple_java_invalid_check(
+    reset_results_dictionary, tmpdir
+):
+    """Check that invocation of comment counting check works correctly."""
+    hello_file = tmpdir.mkdir("subdirectory").join("Hello.java")
+    hello_file.write("/* hello world */")
+    assert hello_file.read() == "/* hello world */"
+    assert len(tmpdir.listdir()) == 1
+    directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
+    hello_file = "Hello.java"
+    invoke.invoke_file_in_directory_check(hello_file, directory)
+    details = report.get_result()
+    assert details is not None
+    report.reset()
+    # this check cannot pass because of the fact that it asks
+    # for standard-line comments, which are not supported by this function
+    invoke.invoke_all_comment_checks(hello_file, directory, 1, "standard-line", "Java")
+    details = report.get_result()
+    assert details is not None
+
+
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
 # pylint: disable=bad-continuation
 def test_comment_counts_check_multiple_java_not_enough(
     reset_results_dictionary, tmpdir

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -32,17 +32,32 @@ def test_run_broken_command_returns_nonzero():
     assert code != 0
 
 
-def test_run_command_grab_output_as_string(tmpdir):
+def test_run_command_grab_output_as_string_correct_command(tmpdir):
     """Check that invocation of command produces correct captured output."""
     tmpdir.mkdir("Hello1")
     tmpdir.mkdir("Hello2")
     tmpdir.mkdir("Hello3")
     assert len(tmpdir.listdir()) == 3
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/"
+    # note that this test case passes even when run in AppVeyor CI
+    # thus suggesting that the ls command is supported on Windows
     output = run.specified_command_get_output("ls " + directory)
     assert "Hello1" in output
     assert "Hello2" in output
     assert "Hello3" in output
+
+
+def test_run_command_grab_output_as_string_incorrect_command(tmpdir):
+    """Check that invocation of command produces correct captured output."""
+    tmpdir.mkdir("Hello1")
+    tmpdir.mkdir("Hello2")
+    tmpdir.mkdir("Hello3")
+    assert len(tmpdir.listdir()) == 3
+    directory = tmpdir.dirname + "/" + tmpdir.basename + "/"
+    # this command will not work correctly because it does not exist
+    # this means that it should not produce any output
+    output = run.specified_command_get_output("gus " + directory)
+    assert output == ""
 
 
 def test_run_invalid_output():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -203,3 +203,24 @@ def test_number_to_words_ordinal_and_cardinal():
     # it is also possible to request cardinal words
     number_as_word = util.get_number_as_words(42, constants.words.Cardinal)
     assert number_as_word == "forty-two"
+
+
+def test_word_diagnostic_single_min_first():
+    """Check to see if diagnostic is produced with a single minimum value."""
+    word_count_dictionary = {1: 4, 2: 5, 3: 10}
+    word_diagnostic = util.get_word_diagnostic(word_count_dictionary)
+    assert word_diagnostic == "in the first"
+
+
+def test_word_diagnostic_single_min_last():
+    """Check to see if diagnostic is produced with a single minimum value."""
+    word_count_dictionary = {1: 10, 2: 5, 3: 4}
+    word_diagnostic = util.get_word_diagnostic(word_count_dictionary)
+    assert word_diagnostic == "in the third"
+
+
+def test_word_diagnostic_empty_dictionary():
+    """Check to see if diagnostic is produced with an empty dictionary."""
+    word_count_dictionary = {}
+    word_diagnostic = util.get_word_diagnostic(word_count_dictionary)
+    assert word_diagnostic == ""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -110,6 +110,22 @@ def test_json_detection_not_found():
     assert is_valid_json is False
 
 
+def test_find_in_empty_dictionary_min():
+    """Check if the None value is found in an empty dictionary"""
+    input = {}
+    found_values = util.get_first_minimum_value(input)
+    assert found_values[0] is None
+    assert found_values[1] is None
+
+
+def test_find_in_empty_dictionary_max():
+    """Check if the None value is found in an empty dictionary"""
+    input = {}
+    found_values = util.get_first_maximum_value(input)
+    assert found_values[0] is None
+    assert found_values[1] is None
+
+
 def test_find_maximum_in_dictionary_single_max():
     """Check if the maximum value is found in a dictionary"""
     input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -109,6 +109,38 @@ def test_json_detection_not_found():
     assert is_valid_json is False
 
 
+def test_find_maximum_in_dictionary_single_max():
+    """Check if the maximum value is found in a dictionary"""
+    input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43}
+    found_values = util.get_first_maximum_value(input)
+    assert found_values[0] == "Mike"
+    assert found_values[1] == 52
+
+
+def test_find_maximum_in_dictionary_multiple_max():
+    """Check if the maximum value is found in a dictionary"""
+    input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43, "Robert": 52}
+    found_values = util.get_first_maximum_value(input)
+    assert found_values[0] == "Mike"
+    assert found_values[1] == 52
+
+
+def test_find_minimum_in_dictionary_single_min():
+    """Check if the minimum value is found in a dictionary"""
+    input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43}
+    found_values = util.get_first_minimum_value(input)
+    assert found_values[0] == "Sarah"
+    assert found_values[1] == 12
+
+
+def test_find_minimum_in_dictionary_multiple_min():
+    """Check if the minimum value is found in a dictionary"""
+    input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43, "Gina": 12}
+    found_values = util.get_first_minimum_value(input)
+    assert found_values[0] == "Sarah"
+    assert found_values[1] == 12
+
+
 def test_relational_operator_exacted_true_not_exacted():
     """Check to see if the exacted relational operator returns True, no exacting."""
     relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -179,7 +179,7 @@ def test_relational_operator_exacted_false_exacted():
     assert relation_value == 100
 
 
-def test_number_to_words_ordinal():
+def test_number_to_words_ordinal_and_cardinal():
     """Check to see if numbers can be converted to ordinal or cardinal words."""
     # note that ordinal is the default
     number_as_word = util.get_number_as_words(42)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -111,7 +111,7 @@ def test_json_detection_not_found():
 
 
 def test_find_in_empty_dictionary_min():
-    """Check if the None value is found in an empty dictionary"""
+    """Check if the None value is found in an empty dictionary."""
     input = {}
     found_values = util.get_first_minimum_value(input)
     assert found_values[0] is None
@@ -119,7 +119,7 @@ def test_find_in_empty_dictionary_min():
 
 
 def test_find_in_empty_dictionary_max():
-    """Check if the None value is found in an empty dictionary"""
+    """Check if the None value is found in an empty dictionary."""
     input = {}
     found_values = util.get_first_maximum_value(input)
     assert found_values[0] is None
@@ -127,7 +127,7 @@ def test_find_in_empty_dictionary_max():
 
 
 def test_find_maximum_in_dictionary_single_max():
-    """Check if the maximum value is found in a dictionary"""
+    """Check if the maximum value is found in a dictionary."""
     input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43}
     found_values = util.get_first_maximum_value(input)
     assert found_values[0] == "Mike"
@@ -135,7 +135,7 @@ def test_find_maximum_in_dictionary_single_max():
 
 
 def test_find_maximum_in_dictionary_multiple_max():
-    """Check if the maximum value is found in a dictionary"""
+    """Check if the maximum value is found in a dictionary."""
     input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43, "Robert": 52}
     found_values = util.get_first_maximum_value(input)
     assert found_values[0] == "Mike"
@@ -143,7 +143,7 @@ def test_find_maximum_in_dictionary_multiple_max():
 
 
 def test_find_minimum_in_dictionary_single_min():
-    """Check if the minimum value is found in a dictionary"""
+    """Check if the minimum value is found in a dictionary."""
     input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43}
     found_values = util.get_first_minimum_value(input)
     assert found_values[0] == "Sarah"
@@ -151,7 +151,7 @@ def test_find_minimum_in_dictionary_single_min():
 
 
 def test_find_minimum_in_dictionary_multiple_min():
-    """Check if the minimum value is found in a dictionary"""
+    """Check if the minimum value is found in a dictionary."""
     input = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43, "Gina": 12}
     found_values = util.get_first_minimum_value(input)
     assert found_values[0] == "Sarah"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@
 import json
 import os
 
+from gator import constants
 from gator import files
 from gator import util
 
@@ -176,3 +177,13 @@ def test_relational_operator_exacted_false_exacted():
     relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10, True)
     assert relation_boolean is False
     assert relation_value == 100
+
+
+def test_number_to_words_ordinal():
+    """Check to see if numbers can be converted to ordinal or cardinal words."""
+    # note that ordinal is the default
+    number_as_word = util.get_number_as_words(42)
+    assert number_as_word == "forty-second"
+    # it is also possible to request cardinal words
+    number_as_word = util.get_number_as_words(42, constants.words.Cardinal)
+    assert number_as_word == "forty-two"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -65,6 +65,18 @@ def test_gatorgrader_home_is_set_after_os_dictionary_set_no_trailing():
     assert "gatorgrader" in gatorgrader_home
 
 
+def test_gatorgrader_home_verification_working_not_verified_none_given():
+    """Check that GATORGRADER_HOME verification is working."""
+    gatorgrader_home_verified = util.verify_gatorgrader_home(None)
+    assert gatorgrader_home_verified is NOT_VERIFIED
+
+
+def test_gatorgrader_home_verification_working_not_verified_blank_given():
+    """Check that GATORGRADER_HOME verification is working."""
+    gatorgrader_home_verified = util.verify_gatorgrader_home("")
+    assert gatorgrader_home_verified is NOT_VERIFIED
+
+
 def test_gatorgrader_home_verification_working_verified(tmp_path):
     """Check that GATORGRADER_HOME verification is working."""
     # this must be a valid directory on the filesystem


### PR DESCRIPTION
This pull request improves the diagnostic messages that are displayed when a check concerning the number of paragraphs in a technical writing document fails. The discuss of the need for this pull request's fix is described in Issue #138.

### What is the current behavior?

Currently, GatorGrader only gives a diagnostic to indicate that the check failed.

### What is the new behavior if this PR is merged?

GatorGrader now gives information about some/all of the paragraphs that are not passing the check.

#### Other information

Note that the initial purpose of this PR was to add the suitable word-count diagnostics. Ultimately, it became possible to also write tests to cover all of the uncovered branches as part of the major refactoring that was required to add the requested diagnostics. As such, this PR handles two issues.

##### This PR has:

- [X] Commit messages that are correctly formatted
- [X] Tests for newly introduced code
- [X] Docstrings for newly introduced code

This PR is a small change that fixes #138 and #168.

#### Developers

@gkapfham
