### PR TITLE
Correctly Capitalize Keys in the JSON Report

### DIFF
--- a/gator/constants.py
+++ b/gator/constants.py
@@ -72,6 +72,10 @@ paths = create_constants(
 )
 
 # define the names of fields in the result table
+# note that the variable name can be capitalized
+# however, the contents of the constant cannot be
+# capitalized because the JSON report that is transmitted
+# between Python and Java expects that the keys are lowercase
 results = create_constants(
     "results", Check="check", Outcome="outcome", Diagnostic="diagnostic"
 )

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -72,7 +72,9 @@ paths = create_constants(
 )
 
 # define the names of fields in the result table
-results = create_constants("results", Check="check", Outcome="outcome", Diagnostic="diagnostic")
+results = create_constants(
+    "results", Check="check", Outcome="outcome", Diagnostic="diagnostic"
+)
 
 # define the version control repository details
 versioncontrol = create_constants("versioncontrol", Master="master")

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -71,9 +71,8 @@ paths = create_constants(
     "paths", Current_Directory=".", Current_Directory_Glob="*.*", Home="gatorgrader"
 )
 
-
 # define the names of fields in the result table
-results = create_constants("results", "Check", "Outcome", "Diagnostic")
+results = create_constants("results", Check="check", Outcome="outcome", Diagnostic="diagnostic")
 
 # define the version control repository details
 versioncontrol = create_constants("versioncontrol", Master="master")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -64,9 +64,9 @@ def test_outputs_constant_defined():
 
 def test_results_constant_defined():
     """Check correctness for the variables in the results constant."""
-    assert constants.results.Check == "Check"
-    assert constants.results.Outcome == "Outcome"
-    assert constants.results.Diagnostic == "Diagnostic"
+    assert constants.results.Check == "check"
+    assert constants.results.Outcome == "outcome"
+    assert constants.results.Diagnostic == "diagnostic"
 
 
 def test_versioncontrol_constant_defined():


### PR DESCRIPTION
Certain keys of the JSON report were capitalized when they should not have been.

### What is the current behavior?

GatorGrader crashes and produces incorrect output because the Gradle plugin cannot find the designated keys in the JSON output.

### What is the new behavior if this PR is merged?

GatorGrader should no longer crash and produce incorrect output.

#### Other information

##### This PR has:

- [X] Commit messages that are correctly formatted
- [X] Tests for newly introduced code
- [X] Docstrings for newly introduced code

This PR is a non-versioned change that fixes a known issue that is not currently in the issue tracker.

#### Developers

@gkapfham