### PR TITLE
Create a Template for Git Commit Messages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 <!-- Please ensure that reviewers are assigned -->
 
 ### What is the current behavior?
+
 <!-- You can link to an open issue here -->
 
 ### What is the new behavior if this PR is merged?
@@ -16,6 +17,10 @@
 
 This PR is a <!-- REQUIRED: replace this comment with one of ["small change", "feature", "compatibility breaking update", "non-versioned change"] -->
 that fixes #<!-- replace this comment with an issue number if applicable -->
+
+<!-- We required the above line statement because GatorGrader uses: -->
+<!-- https://github.com/Michionlion/pr-tag-release -->
+<!-- to automatically generate a tag and a release from a merged PR -->
 
 #### Developers
 

--- a/.gitmessage
+++ b/.gitmessage
@@ -17,15 +17,14 @@
 #    type, an optional scope, and a subject
 #       + <type> describes the kind of change that this commit is
 #                providing. Allowed types are:
-#             * feat (feature)
-#             * fix (bug fix)
-#             * docs (documentation)
-#             * style (fix formatting)
+#             * feat (add feature)
+#             * fix (fix defect)
+#             * docs (add documentation)
+#             * style (improve/fix formatting)
 #             * refactor (improve the code, no new features)
-#             * test (add new test(s))
+#             * test (add test(s))
 #             * chore (maintenance or infrastructure)
-#       + <scope> can be anything specifying the place of the commit
-#                 change
+#       + <scope> can be anything specifying commit change place
 #       + <subject> is a very short description of the change, in
 #                   the following format:
 #             * Imperative, present tense: "change" not

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,35 @@
+# Hello GatorGrader contributor!
+#
+# We just wanted to let you know that we care a great deal about
+# making our Git history clean, maintainable, and easy to access for
+# all of our contributors. Commit messages are very important to us,
+# which is why we have a strict commit message policy in place.
+# Please use the following guidelines to format all your commit
+# messages:
+#     <type>(<scope>): <subject>
+#
+# Please note that:
+#
+#  - The message is a single line of about 72 characters that
+#    contains a succinct description of the change. It contains a
+#    type, an optional scope, and a subject
+#       + <type> describes the kind of change that this commit is
+#                providing. Allowed types are:
+#             * feat (feature)
+#             * fix (bug fix)
+#             * docs (documentation)
+#             * style (formatting, missing semicolons, …)
+#             * refactor
+#             * test (when adding missing tests)
+#             * chore (maintain)
+#       + <scope> can be anything specifying the place of the commit
+#                 change
+#       + <subject> is a very short description of the change, in
+#                   the following format:
+#             * imperative, present tense: “change” not
+#               “changed”/“changes”
+#             * no capitalised first letter
+#             * no dot (.) at the end
+#
+# Thanks for following the GatorGrader commit message template!
+# References: https://backlog.com/blog/git-commit-messages-bold-daring/

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,6 +1,6 @@
 
 
-# Hello GatorGrader contributor! We appreciate your hard work!
+# Hello GatorGrader contributor, we appreciate your hard work!
 #
 # The maintainers wanted to let you know that we really care about
 # making our Git history clean, maintainable, and easy to access for

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,6 +1,6 @@
 
 
-# Hello GatorGrader contributor!
+# Hello GatorGrader contributor! We appreciate your hard work!
 #
 # We just wanted to let you know that we care a great deal about
 # making our Git history clean, maintainable, and easy to access for

--- a/.gitmessage
+++ b/.gitmessage
@@ -2,7 +2,7 @@
 
 # Hello GatorGrader contributor! We appreciate your hard work!
 #
-# We just wanted to let you know that we care a great deal about
+# The maintainers wanted to let you know that we really care about
 # making our Git history clean, maintainable, and easy to access for
 # all of our contributors. Commit messages are very important to us,
 # which is why we have a strict commit message policy in place.

--- a/.gitmessage
+++ b/.gitmessage
@@ -4,8 +4,8 @@
 # making our Git history clean, maintainable, and easy to access for
 # all of our contributors. Commit messages are very important to us,
 # which is why we have a strict commit message policy in place.
-# Please use the following guidelines to format all your commit
-# messages:
+# Please use this template to format all your commit messages:
+#
 #     <type>(<scope>): <subject>
 #
 # Please note that:

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,4 +1,5 @@
 
+
 # Hello GatorGrader contributor!
 #
 # We just wanted to let you know that we care a great deal about

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,3 +1,4 @@
+
 # Hello GatorGrader contributor!
 #
 # We just wanted to let you know that we care a great deal about
@@ -18,18 +19,18 @@
 #             * feat (feature)
 #             * fix (bug fix)
 #             * docs (documentation)
-#             * style (formatting, missing semicolons, …)
-#             * refactor
-#             * test (when adding missing tests)
-#             * chore (maintain)
+#             * style (fix formatting)
+#             * refactor (improve the code, no new features)
+#             * test (add new test(s))
+#             * chore (maintenance or infrastructure)
 #       + <scope> can be anything specifying the place of the commit
 #                 change
 #       + <subject> is a very short description of the change, in
 #                   the following format:
-#             * imperative, present tense: “change” not
-#               “changed”/“changes”
-#             * no capitalised first letter
-#             * no dot (.) at the end
+#             * Imperative, present tense: "change" not
+#               "changed" or "changes"
+#             * Capitalised first letter
+#             * Dot (.) at the end
 #
 # Thanks for following the GatorGrader commit message template!
 # References: https://backlog.com/blog/git-commit-messages-bold-daring/

--- a/.gitmessage
+++ b/.gitmessage
@@ -31,6 +31,7 @@
 #               "changed" or "changes"
 #             * Capitalised first letter
 #             * Dot (.) at the end
+#             * No spelling mistakes
 #
 # Thanks for following the GatorGrader commit message template!
 # References: https://backlog.com/blog/git-commit-messages-bold-daring/

--- a/.gitmessage
+++ b/.gitmessage
@@ -13,8 +13,8 @@
 # Please note that:
 #
 #  - The message is a single line of about 72 characters that
-#    contains a succinct description of the change. It contains a
-#    type, an optional scope, and a subject
+#    contains a succinct description of the change. It contains an
+#    optional type, an optional scope, and a required subject
 #       + <type> describes the kind of change that this commit is
 #                providing. Allowed types are:
 #             * feat (add feature)


### PR DESCRIPTION
This PR provides a template for Git commit messages.

### What is the current behavior?

Someone can type a commit message in their own format.
We only ask them to change the message if it is really bad.

### What is the new behavior if this PR is merged?

This will make the commit messages more consistent. I'm open to different
formats for the commit message, but picked this one after reading some articles.
I will try it and adjust it as needed. What would you prefer?

##### This PR has:

- [X] Commit messages that are correctly formatted

This PR is a small change.

#### Developers

@gkapfham