### PR TITLE
Support Wildcards in File Fragment Checking

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,2 @@
+exclude_paths:
+  - 'tests/**'

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,2 +1,5 @@
+---
 exclude_paths:
   - 'tests/**'
+  - '.github/**'
+  - '.github/**/*'

--- a/.gitmessage
+++ b/.gitmessage
@@ -23,6 +23,7 @@
 #             * coms (add or modify code documentation)
 #             * style (improve code or doc formatting)
 #             * refactor (improve the code, no new features)
+#             * perf (improve performance, no new features)
 #             * test (add or modify test(s))
 #             * chore (maintenance or infrastructure)
 #       + <scope> can be anything specifying commit change place

--- a/.gitmessage
+++ b/.gitmessage
@@ -19,10 +19,10 @@
 #                providing. Allowed types are:
 #             * feat (add feature)
 #             * fix (fix defect)
-#             * docs (add documentation)
+#             * docs (add user documentation)
 #             * style (improve/fix formatting)
 #             * refactor (improve the code, no new features)
-#             * test (add test(s))
+#             * test (add or modify test(s))
 #             * chore (maintenance or infrastructure)
 #       + <scope> can be anything specifying commit change place
 #       + <subject> is a very short description of the change, in

--- a/.gitmessage
+++ b/.gitmessage
@@ -19,7 +19,7 @@
 #                providing. Allowed types are:
 #             * feat (add feature)
 #             * fix (fix defect)
-#             * docs (add user documentation)
+#             * docs (add or modify user documentation)
 #             * style (improve/fix formatting)
 #             * refactor (improve the code, no new features)
 #             * test (add or modify test(s))

--- a/.gitmessage
+++ b/.gitmessage
@@ -20,6 +20,7 @@
 #             * feat (add feature)
 #             * fix (fix defect)
 #             * docs (add or modify user documentation)
+#             * coms (add or modify code documentation)
 #             * style (improve/fix formatting)
 #             * refactor (improve the code, no new features)
 #             * test (add or modify test(s))

--- a/.gitmessage
+++ b/.gitmessage
@@ -14,14 +14,14 @@
 #
 #  - The message is a single line of about 72 characters that
 #    contains a succinct description of the change. It contains an
-#    optional type, an optional scope, and a required subject
+#    encouraged type, an optional scope, and a required subject.
 #       + <type> describes the kind of change that this commit is
 #                providing. Allowed types are:
 #             * feat (add feature)
 #             * fix (fix defect)
 #             * docs (add or modify user documentation)
 #             * coms (add or modify code documentation)
-#             * style (improve/fix formatting)
+#             * style (improve code or doc formatting)
 #             * refactor (improve the code, no new features)
 #             * test (add or modify test(s))
 #             * chore (maintenance or infrastructure)

--- a/gator/comments.py
+++ b/gator/comments.py
@@ -16,11 +16,6 @@ SINGLELINECOMMENT_RE_PYTHON = r"""^(?:[^"#\\]|\"(?:[^\"\\]|\\.)*\"|
 /(?:[^#"\\]|\\.)|/\"(?:[^\"\\]|\\.)*\"|\\.)*#(.*)$"""
 MULTILINECOMMENT_RE_PYTHON = r'^[ \t]*"""(.*?)"""[ \t]*$'
 
-# Note that all of these functions also return an empty dictionary
-# (i.e., {}) so that it matches the return signature of the
-# other analogous function that counts the words and returns
-# a dictionary of the {number of a paragraph, word count in paragraph}
-
 
 def count_singleline_java_comment(contents):
     """Count the number of singleline Java comments in the code."""

--- a/gator/comments.py
+++ b/gator/comments.py
@@ -2,6 +2,7 @@
 
 import re
 
+from gator import constants
 
 # References for the regular expressions:
 # https://stackoverflow.com/questions/15423658/regular-expression-for-single-line-comments
@@ -25,7 +26,8 @@ def count_singleline_java_comment(contents):
     """Count the number of singleline Java comments in the code."""
     pattern = re.compile(SINGLELINECOMMENT_RE_JAVA, re.MULTILINE | re.VERBOSE)
     matches = pattern.findall(contents)
-    return len(matches), {}
+    matches_count = len(matches)
+    return matches_count, {constants.markers.First: matches_count}
 
 
 def count_singleline_python_comment(contents):

--- a/gator/comments.py
+++ b/gator/comments.py
@@ -34,18 +34,21 @@ def count_singleline_python_comment(contents):
     """Count the number of singleline Python comments in the code."""
     pattern = re.compile(SINGLELINECOMMENT_RE_PYTHON, re.MULTILINE)
     matches = pattern.findall(contents)
-    return len(matches), {}
+    matches_count = len(matches)
+    return matches_count, {constants.markers.First: matches_count}
 
 
 def count_multiline_java_comment(contents):
     """Count the number of multiline Java comments in the code."""
     pattern = re.compile(MULTILINECOMMENT_RE_JAVA, re.MULTILINE)
     matches = pattern.findall(contents)
-    return len(matches), {}
+    matches_count = len(matches)
+    return matches_count, {constants.markers.First: matches_count}
 
 
 def count_multiline_python_comment(contents):
     """Count the number of multiline Python comments in the code."""
     pattern = re.compile(MULTILINECOMMENT_RE_PYTHON, re.MULTILINE | re.DOTALL)
     matches = pattern.findall(contents)
-    return len(matches), {}
+    matches_count = len(matches)
+    return matches_count, {constants.markers.First: matches_count}

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -45,8 +45,9 @@ markers = create_constants(
     Nothing="",
     Space=" ",
     Tab="   ",
+    File="file",
     Of_File="of file",
-    File="in a file",
+    In_A_File="in a file",
     First=1,
     Invalid=-1,
 )

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -46,6 +46,7 @@ markers = create_constants(
     Space=" ",
     Tab="   ",
     File="in a file",
+    First=1,
     Invalid=-1,
 )
 

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -29,6 +29,9 @@ comments = create_constants(
 # define the environment variables for the program
 environmentvariables = create_constants("environmentvariables", Home="GATORGRADER_HOME")
 
+# define reference function names in the program
+functions = create_constants("functions", Count_Total_Words="count_total_words")
+
 # define the programming languages for comment checks
 languages = create_constants("languages", "Java", "Python")
 

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -45,6 +45,7 @@ markers = create_constants(
     Nothing="",
     Space=" ",
     Tab="   ",
+    Of_File="of file",
     File="in a file",
     First=1,
     Invalid=-1,

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -21,22 +21,32 @@ def entity_greater_than_count(
 
 
 def count_entities(given_file, containing_directory, checking_function):
-    """Count the number of entities for the file in the directory."""
+    """Count the number of entities for the file(s) in the directory."""
+    # create an empty dictionary of filenames and an internal dictionary
+    file_counts_dictionary = {}
     # create a path for the given file and its containing directory
     # note that this call does not specify any *args and thus there
     # are no directories between the home directory and the file
-    file_for_checking = files.create_path(file=given_file, home=containing_directory)
-    # start the count of the number of entities at zero, assuming none found yet
-    file_contents_count = 0
-    # create an empty dictionary of the counts
-    file_contents_count_dictionary = {}
-    # a valid file exists and thus it is acceptable to perform the checking
-    if file_for_checking.is_file():
-        # extract the text from the file_for_checking
-        file_contents = file_for_checking.read_text()
-        # use the provided checking_function to check the contents of the file
-        # note this works since Python supports passing a function to a function
-        file_contents_count, file_contents_count_dictionary = checking_function(
-            file_contents
-        )
-    return file_contents_count, file_contents_count_dictionary
+    for file_for_checking in files.create_paths(
+        file=given_file, home=containing_directory
+    ):
+        # start the count of the number of entities at zero, assuming none found yet
+        file_contents_count = 0
+        # create an empty dictionary of the counts
+        file_contents_count_dictionary = {}
+        # a valid file exists and thus it is acceptable to perform the checking
+        if file_for_checking.is_file():
+            # extract the text from the file_for_checking
+            file_contents = file_for_checking.read_text()
+            # use the provided checking_function to check the contents of the file
+            # note this works since Python supports passing a function to a function
+            file_contents_count, file_contents_count_dictionary = checking_function(
+                file_contents
+            )
+            file_counts_dictionary[
+                file_for_checking.name
+            ] = file_contents_count_dictionary
+    file_contents_count_overall = util.get_first_minimum_value_deep(
+        file_counts_dictionary
+    )[1][1]
+    return file_contents_count_overall, file_counts_dictionary

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -42,8 +42,18 @@ def count_entities(given_file, containing_directory, checking_function):
         file_contents_count, file_contents_count_dictionary = checking_function(
             file_contents
         )
-        # associate these file counts with the filename in a dictionary
-        file_counts_dictionary[file_for_checking.name] = file_contents_count_dictionary
+        # the checking_function returned a dictionary of form {entity: count}
+        # so we should store this dictionary insider the containing dictionary
+        # this case would occur for checks like number of words in paragraphs
+        if file_contents_count_dictionary:
+            # associate these file counts with the filename in a dictionary
+            file_counts_dictionary[file_for_checking.name] = file_contents_count_dictionary
+        # the checking_function did not return a dictionary because that was
+        # not sensible for the type of check (e.g., counting paragraphs)
+        # so we should make a "dummy" dictionary containing the entity count
+        else:
+            file_contents_count_dictionary = {1: file_contents_count}
+            file_counts_dictionary[file_for_checking.name] = file_contents_count_dictionary
     # find the minimum count for all paragraphs across all of the files
     # assume that nothing was found and the count is zero and prove otherwise
     file_contents_count_overall = 0

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -1,7 +1,8 @@
 """Count entities with provided functions."""
 
-from gator import util
+from gator import constants
 from gator import files
+from gator import util
 
 
 # pylint: disable=bad-continuation
@@ -65,7 +66,7 @@ def count_entities(given_file, containing_directory, checking_function):
     file_contents_count_overall = file_contents_count
     # there is a dictionary of counts for files, so deeply find the minimum
     # as long as the count is not of the total words in a file or output
-    if file_counts_dictionary and checking_function.__name__ != "count_total_words":
+    if file_counts_dictionary and checking_function.__name__ != constants.functions.Count_Total_Words:
         file_contents_count_overall = util.get_first_minimum_value_deep(
             file_counts_dictionary
         )[1][1]

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -43,10 +43,13 @@ def count_entities(given_file, containing_directory, checking_function):
             file_contents_count, file_contents_count_dictionary = checking_function(
                 file_contents
             )
+            # associate these file counts with the filename in a dictionary
             file_counts_dictionary[
                 file_for_checking.name
             ] = file_contents_count_dictionary
+    # find the minimum count for all paragraphs across all of the files
     file_contents_count_overall = util.get_first_minimum_value_deep(
         file_counts_dictionary
     )[1][1]
+    # return the overall minimum count and the nested file count dictionary
     return file_contents_count_overall, file_counts_dictionary

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -24,6 +24,8 @@ def count_entities(given_file, containing_directory, checking_function):
     """Count the number of entities for the file(s) in the directory."""
     # create an empty dictionary of filenames and an internal dictionary
     file_counts_dictionary = {}
+    # if the file is not found in the directory, the count is zero
+    file_contents_count = 0
     # create a path for the given file and its containing directory
     # note that this call does not specify any *args and thus there
     # are no directories between the home directory and the file
@@ -60,11 +62,12 @@ def count_entities(given_file, containing_directory, checking_function):
             ] = file_contents_count_dictionary
     # find the minimum count for all paragraphs across all of the files
     # assume that nothing was found and the count is zero and prove otherwise
-    file_contents_count_overall = 0
+    file_contents_count_overall = file_contents_count
     # there is a dictionary of counts for files, so deeply find the minimum
-    if file_counts_dictionary:
+    # as long as the count is not of the total words in a file or output
+    if file_counts_dictionary and checking_function.__name__ != "count_total_words":
         file_contents_count_overall = util.get_first_minimum_value_deep(
             file_counts_dictionary
         )[1][1]
-    # return the overall minimum count and the nested file count dictionary
+    # return the overall requested count and the nested file count dictionary
     return file_contents_count_overall, file_counts_dictionary

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -65,7 +65,7 @@ def count_entities(given_file, containing_directory, checking_function):
     # assume that nothing was found and the count is zero and prove otherwise
     file_contents_count_overall = file_contents_count
     # there is a dictionary of counts for files, so deeply find the minimum
-    # as long as the count is not of the total words in a file or output
+    # as long as the count is not of the total words in a file
     if file_counts_dictionary and checking_function.__name__ != constants.functions.Count_Total_Words:
         file_contents_count_overall = util.get_first_minimum_value_deep(
             file_counts_dictionary

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -43,9 +43,7 @@ def count_entities(given_file, containing_directory, checking_function):
             file_contents
         )
         # associate these file counts with the filename in a dictionary
-        file_counts_dictionary[
-            file_for_checking.name
-        ] = file_contents_count_dictionary
+        file_counts_dictionary[file_for_checking.name] = file_contents_count_dictionary
     # find the minimum count for all paragraphs across all of the files
     # assume that nothing was found and the count is zero and prove otherwise
     file_contents_count_overall = 0

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -47,13 +47,17 @@ def count_entities(given_file, containing_directory, checking_function):
         # this case would occur for checks like number of words in paragraphs
         if file_contents_count_dictionary:
             # associate these file counts with the filename in a dictionary
-            file_counts_dictionary[file_for_checking.name] = file_contents_count_dictionary
+            file_counts_dictionary[
+                file_for_checking.name
+            ] = file_contents_count_dictionary
         # the checking_function did not return a dictionary because that was
         # not sensible for the type of check (e.g., counting paragraphs)
         # so we should make a "dummy" dictionary containing the entity count
         else:
             file_contents_count_dictionary = {1: file_contents_count}
-            file_counts_dictionary[file_for_checking.name] = file_contents_count_dictionary
+            file_counts_dictionary[
+                file_for_checking.name
+            ] = file_contents_count_dictionary
     # find the minimum count for all paragraphs across all of the files
     # assume that nothing was found and the count is zero and prove otherwise
     file_contents_count_overall = 0

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -48,8 +48,12 @@ def count_entities(given_file, containing_directory, checking_function):
                 file_for_checking.name
             ] = file_contents_count_dictionary
     # find the minimum count for all paragraphs across all of the files
-    file_contents_count_overall = util.get_first_minimum_value_deep(
-        file_counts_dictionary
-    )[1][1]
+    # assume that nothing was found and the count is zero and prove otherwise
+    file_contents_count_overall = 0
+    # there is a dictionary of counts for files, so deeply find the minimum
+    if file_counts_dictionary:
+        file_contents_count_overall = util.get_first_minimum_value_deep(
+            file_counts_dictionary
+        )[1][1]
     # return the overall minimum count and the nested file count dictionary
     return file_contents_count_overall, file_counts_dictionary

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -66,7 +66,10 @@ def count_entities(given_file, containing_directory, checking_function):
     file_contents_count_overall = file_contents_count
     # there is a dictionary of counts for files, so deeply find the minimum
     # as long as the count is not of the total words in a file
-    if file_counts_dictionary and checking_function.__name__ != constants.functions.Count_Total_Words:
+    if (
+        file_counts_dictionary
+        and checking_function.__name__ != constants.functions.Count_Total_Words
+    ):
         file_contents_count_overall = util.get_first_minimum_value_deep(
             file_counts_dictionary
         )[1][1]

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -35,18 +35,17 @@ def count_entities(given_file, containing_directory, checking_function):
         # create an empty dictionary of the counts
         file_contents_count_dictionary = {}
         # a valid file exists and thus it is acceptable to perform the checking
-        if file_for_checking.is_file():
-            # extract the text from the file_for_checking
-            file_contents = file_for_checking.read_text()
-            # use the provided checking_function to check the contents of the file
-            # note this works since Python supports passing a function to a function
-            file_contents_count, file_contents_count_dictionary = checking_function(
-                file_contents
-            )
-            # associate these file counts with the filename in a dictionary
-            file_counts_dictionary[
-                file_for_checking.name
-            ] = file_contents_count_dictionary
+        # extract the text from the file_for_checking
+        file_contents = file_for_checking.read_text()
+        # use the provided checking_function to check the contents of the file
+        # note this works since Python supports passing a function to a function
+        file_contents_count, file_contents_count_dictionary = checking_function(
+            file_contents
+        )
+        # associate these file counts with the filename in a dictionary
+        file_counts_dictionary[
+            file_for_checking.name
+        ] = file_contents_count_dictionary
     # find the minimum count for all paragraphs across all of the files
     # assume that nothing was found and the count is zero and prove otherwise
     file_contents_count_overall = 0

--- a/gator/files.py
+++ b/gator/files.py
@@ -20,14 +20,8 @@ def create_paths(*args, file="", home):
     # to create a list of all files matched by the glob
     file_or_glob_path = create_path(*args, file=file, home=home)
     home_directory_globbed = [Path(p) for p in glob(str(file_or_glob_path))]
-    # iterate through the list and yield the files as matching Path objects
-    # if there are files that are incorrect, they will not be in the list
+    # return this list of Path objects resulting from glob application
     return home_directory_globbed
-    # for current_file in home_directory_globbed:
-    # current_file_path = create_path(*args, file=current_file, home=home)
-    # print("current_file_path")
-    # print(current_file_path)
-    # yield
 
 
 def create_path(*args, file="", home):

--- a/gator/files.py
+++ b/gator/files.py
@@ -22,9 +22,12 @@ def create_paths(*args, file="", home):
     home_directory_globbed = [Path(p) for p in glob(str(file_or_glob_path))]
     # iterate through the list and yield the files as matching Path objects
     # if there are files that are incorrect, they will not be in the list
-    for current_file in home_directory_globbed:
-        current_file_path = create_path(*args, file=current_file, home=home)
-        yield current_file_path
+    return home_directory_globbed
+    # for current_file in home_directory_globbed:
+    # current_file_path = create_path(*args, file=current_file, home=home)
+    # print("current_file_path")
+    # print(current_file_path)
+    # yield
 
 
 def create_path(*args, file="", home):

--- a/gator/files.py
+++ b/gator/files.py
@@ -21,6 +21,7 @@ def create_paths(*args, file="", home):
     file_or_glob_path = create_path(*args, file=file, home=home)
     home_directory_globbed = [Path(p) for p in glob(str(file_or_glob_path))]
     # iterate through the list and yield the files as matching Path objects
+    # if there are files that are incorrect, they will not be in the list
     for current_file in home_directory_globbed:
         current_file_path = create_path(*args, file=current_file, home=home)
         yield current_file_path

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -198,13 +198,12 @@ def count_entities(
     for file_for_checking in files.create_paths(
         file=given_file, home=containing_directory
     ):
-        # file is available and the contents are not provided
+        # an actual file is available and command contents are not provided
         # the context for this condition is when the function checks file contents
-        if file_for_checking.is_file() and contents is constants.markers.Nothing:
-            # read the text from the file and then check for the chosen fragment
-            file_contents = file_for_checking.read_text()
-            file_contents_count = checking_function(file_contents, chosen_fragment)
-            file_contents_count_dictionary[file_for_checking.name] = file_contents_count
+        # read the text from the file and then check for the chosen fragment
+        file_contents = file_for_checking.read_text()
+        file_contents_count = checking_function(file_contents, chosen_fragment)
+        file_contents_count_dictionary[file_for_checking.name] = file_contents_count
     # return the minimum value and the entire dictionary of counts
     minimum_pair = util.get_first_minimum_value(file_contents_count_dictionary)
     file_contents_count = minimum_pair[1]

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -198,10 +198,8 @@ def count_entities(
     for file_for_checking in files.create_paths(
         file=given_file, home=containing_directory
     ):
-        # create a Path object to the chosen file in the containing directory
         # file is available and the contents are not provided
-        # the context for this condition is when the function checks
-        # the contents of a specified file
+        # the context for this condition is when the function checks file contents
         if file_for_checking.is_file() and contents is constants.markers.Nothing:
             # read the text from the file and then check for the chosen fragment
             file_contents = file_for_checking.read_text()

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -244,11 +244,11 @@ def invoke_all_word_count_checks(
     # across all of the files specified (i.e., those matched by wildcards)
     word_diagnostic, filename = util.get_word_diagnostic(actual_count_dictionary)
     # there is no need for a filename diagnostic unless there are multiple results
-    filename_diagnostic = ""
+    filename_diagnostic = constants.markers.Nothing
     # there is a filename, which means that there was a wildcard specified
     # and thus this diagnostic is for one file; give name at the end
     if filename:
-        filename_diagnostic = "of file" + constants.markers.Space + filename
+        filename_diagnostic = constants.markers.Of_File + constants.markers.Space + filename
     # since there is a word_diagnostic, add it to the conclusion of diagnostic
     # otherwise, the conclusion will always contain "in every"
     if word_diagnostic:

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -78,11 +78,12 @@ def invoke_all_comment_checks(
     """Perform the comment check and return the results."""
     met_or_exceeded_count = 0
     actual_count = 0
+    comment_count_details = {}
     # check single-line comments
     if comment_type == constants.comments.Single_Line:
         # check comments in Java
         if language == constants.languages.Java:
-            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, comment_count_details = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,
@@ -91,7 +92,7 @@ def invoke_all_comment_checks(
             )
         # check comments in Python
         if language == constants.languages.Python:
-            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, comment_count_details = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,
@@ -158,8 +159,22 @@ def invoke_all_comment_checks(
             + " comment(s)"
         )
     # create the diagnostic and the report the result
-    diagnostic = "Found " + str(actual_count) + " comment(s) in the specified file"
+    # produce the diagnostic and report the result
+    flat_comment_count_details = util.flatten_dictionary_values(comment_count_details)
+    fragment_diagnostic = util.get_file_diagnostic(flat_comment_count_details)
+    diagnostic = (
+        "Found "
+        + str(actual_count)
+        + constants.markers.Space
+        + "fragment(s)"
+        + constants.markers.Space
+        + fragment_diagnostic
+        + constants.markers.Space
+        + "or the output"
+    )
     report_result(met_or_exceeded_count, message, diagnostic)
+    # diagnostic = "Found " + str(actual_count) + " comment(s) in the specified file"
+    # report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count
 
 

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -241,13 +241,21 @@ def invoke_all_word_count_checks(
     # This diagnostic signals the fact that there was at least
     # a single paragraph that had a word count below the standard
     # set for all of the paragraphs in the technical writing
-    word_diagnostic = util.get_word_diagnostic(actual_count_dictionary)
+    # across all of the files specified (i.e., those matched by wildcards)
+    word_diagnostic, filename = util.get_word_diagnostic(actual_count_dictionary)
+    # there is no need for a filename diagnostic unless there are multiple results
+    filename_diagnostic = ""
+    # there is a filename, which means that there was a wildcard specified
+    # and thus this diagnostic is for one file; give name at the end
+    if filename:
+        filename_diagnostic = "of file" + constants.markers.Space + filename
     diagnostic = (
         "Found "
         + str(actual_count)
         + constants.markers.Space
         + conclusion.replace(constants.words.In_Every, word_diagnostic)
         + constants.markers.Space
+        + filename_diagnostic
     )
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -173,7 +173,6 @@ def invoke_all_comment_checks(
         + "or the output"
     )
     report_result(met_or_exceeded_count, message, diagnostic)
-    # diagnostic = "Found " + str(actual_count) + " comment(s) in the specified file"
     # report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count
 
@@ -184,8 +183,6 @@ def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=Fals
     met_or_exceeded_count, actual_count, actual_count_dictionary = entities.entity_greater_than_count(
         filecheck, directory, expected_count, fragments.count_paragraphs, exact
     )
-    # print("actual_count_dictionary")
-    # print(actual_count_dictionary)
     # create the message and the diagnostic
     if not exact:
         # create an "at least" message, which is the default

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -181,9 +181,11 @@ def invoke_all_comment_checks(
 def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=False):
     """Perform the paragraph check and return the results."""
     met_or_exceeded_count = 0
-    met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
+    met_or_exceeded_count, actual_count, actual_count_dictionary = entities.entity_greater_than_count(
         filecheck, directory, expected_count, fragments.count_paragraphs, exact
     )
+    # print("actual_count_dictionary")
+    # print(actual_count_dictionary)
     # create the message and the diagnostic
     if not exact:
         # create an "at least" message, which is the default
@@ -209,8 +211,20 @@ def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=Fals
             + constants.markers.Space
             + "paragraph(s)"
         )
+    # produce the diagnostic and report the result
+    flat_actual_count_dictionary = util.flatten_dictionary_values(actual_count_dictionary)
+    fragment_diagnostic = util.get_file_diagnostic(flat_actual_count_dictionary)
+    diagnostic = (
+        "Found "
+        + str(actual_count)
+        + constants.markers.Space
+        + "paragraph(s)"
+        + constants.markers.Space
+        + fragment_diagnostic
+        + constants.markers.Space
+        + constants.markers.File
+    )
     # create the diagnostic and then report the result
-    diagnostic = "Found " + str(actual_count) + " paragraph(s) in the specified file"
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count
 

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -357,8 +357,6 @@ def invoke_all_fragment_checks(
                 + "' fragment"
             )
     # produce the diagnostic and report the result
-    print("Working with this dictionary: ")
-    print(actual_count_dictionary)
     fragment_diagnostic = util.get_file_diagnostic(actual_count_dictionary)
     diagnostic = (
         "Found "

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -433,6 +433,12 @@ def invoke_all_regex_checks(
         contents,
         exact,
     )
+    print("met_or_exceeded_count")
+    print(met_or_exceeded_count)
+    print("actual_count")
+    print(actual_count)
+    print("actual_count_dictionary")
+    print(actual_count_dictionary)
     # create a message for a file in directory
     if (
         filecheck is not constants.markers.Nothing
@@ -492,7 +498,7 @@ def invoke_all_regex_checks(
     diagnostic = (
         "Found "
         + str(actual_count)
-        + " matches of the specified regular expression in the output or the specified file"
+        + " matches of the regular expression in output or specified file"
     )
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -103,7 +103,7 @@ def invoke_all_comment_checks(
     elif comment_type == constants.comments.Multiple_Line:
         # check comments in Java
         if language == constants.languages.Java:
-            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, comment_count_details = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,
@@ -112,7 +112,7 @@ def invoke_all_comment_checks(
             )
         # check comments in Python
         if language == constants.languages.Python:
-            met_or_exceeded_count, actual_count, _ = entities.entity_greater_than_count(
+            met_or_exceeded_count, actual_count, comment_count_details = entities.entity_greater_than_count(
                 filecheck,
                 directory,
                 expected_count,

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -249,11 +249,15 @@ def invoke_all_word_count_checks(
     # and thus this diagnostic is for one file; give name at the end
     if filename:
         filename_diagnostic = "of file" + constants.markers.Space + filename
+    # since there is a word_diagnostic, add it to the conclusion of diagnostic
+    # otherwise, the conclusion will always contain "in every"
+    if word_diagnostic:
+        conclusion = conclusion.replace(constants.words.In_Every, word_diagnostic)
     diagnostic = (
         "Found "
         + str(actual_count)
         + constants.markers.Space
-        + conclusion.replace(constants.words.In_Every, word_diagnostic)
+        + conclusion
         + constants.markers.Space
         + filename_diagnostic
     )

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -248,7 +248,9 @@ def invoke_all_word_count_checks(
     # there is a filename, which means that there was a wildcard specified
     # and thus this diagnostic is for one file; give name at the end
     if filename:
-        filename_diagnostic = constants.markers.Of_File + constants.markers.Space + filename
+        filename_diagnostic = (
+            constants.markers.Of_File + constants.markers.Space + filename
+        )
     # since there is a word_diagnostic, add it to the conclusion of diagnostic
     # otherwise, the conclusion will always contain "in every"
     if word_diagnostic:

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -166,7 +166,7 @@ def invoke_all_comment_checks(
         "Found "
         + str(actual_count)
         + constants.markers.Space
-        + "fragment(s)"
+        + "comment(s)"
         + constants.markers.Space
         + fragment_diagnostic
         + constants.markers.Space

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -433,12 +433,6 @@ def invoke_all_regex_checks(
         contents,
         exact,
     )
-    print("met_or_exceeded_count")
-    print(met_or_exceeded_count)
-    print("actual_count")
-    print(actual_count)
-    print("actual_count_dictionary")
-    print(actual_count_dictionary)
     # create a message for a file in directory
     if (
         filecheck is not constants.markers.Nothing
@@ -494,11 +488,25 @@ def invoke_all_regex_checks(
                 + regex
                 + "' regular expression"
             )
+    # only construct a diagnostic for a file if needed
+    conclusion = ""
+    # use the default name of the file
+    violating_file_name = filecheck
+    # since a wildcard was specified, pick the file that most violates the check
+    if actual_count_dictionary and filecheck is not constants.markers.Nothing:
+        violating_entity_details = util.get_first_value(actual_count_dictionary)
+        violating_file_name = violating_entity_details[0]
+    # create a conclusion to tag onto the diagnostic's ending
+    if filecheck is not constants.markers.Nothing:
+        conclusion = "or " + violating_file_name
     # create the diagnostic message and report the result
     diagnostic = (
         "Found "
         + str(actual_count)
-        + " matches of the regular expression in output or specified file"
+        + constants.markers.Space
+        + "match(es) of the regular expression in output"
+        + constants.markers.Space
+        + conclusion
     )
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -212,7 +212,9 @@ def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=Fals
             + "paragraph(s)"
         )
     # produce the diagnostic and report the result
-    flat_actual_count_dictionary = util.flatten_dictionary_values(actual_count_dictionary)
+    flat_actual_count_dictionary = util.flatten_dictionary_values(
+        actual_count_dictionary
+    )
     fragment_diagnostic = util.get_file_diagnostic(flat_actual_count_dictionary)
     diagnostic = (
         "Found "

--- a/gator/util.py
+++ b/gator/util.py
@@ -58,7 +58,7 @@ def get_symbol_answer(boolean_value):
 
 
 def get_first_value_deep(input_dictionary, finder=min):
-    """Iteratively return values matched by a finder function."""
+    """Iteratively return deep values matched by a finder function."""
     filename_count_dictionary = {}
     for filename, paragraph_count_dictionary in input_dictionary.items():
         filename_minimum = get_first_value(paragraph_count_dictionary, finder)

--- a/gator/util.py
+++ b/gator/util.py
@@ -57,6 +57,16 @@ def get_symbol_answer(boolean_value):
     return "✘"
 
 
+def get_first_value_deep(input_dictionary, finder=min):
+    """Iteratively return values matched by a finder function."""
+    filename_count_dictionary = {}
+    for filename, paragraph_count_dictionary in input_dictionary.items():
+        filename_minimum = get_first_value(paragraph_count_dictionary, finder)
+        filename_count_dictionary[filename] = filename_minimum
+    outer_found_value = get_first_value(filename_count_dictionary, finder)
+    return outer_found_value
+
+
 def get_first_value(input_dictionary, finder=min):
     """Return the values matched by a finder function."""
     # pick the key and value that is matched by the finder
@@ -78,6 +88,16 @@ def get_first_maximum_value(input_dictionary):
 def get_first_minimum_value(input_dictionary):
     """Return the first minimum value."""
     return get_first_value(input_dictionary, min)
+
+
+def get_first_maximum_value_deep(input_dictionary):
+    """Return the first maximum value deep."""
+    return get_first_value_deep(input_dictionary, max)
+
+
+def get_first_minimum_value_deep(input_dictionary):
+    """Return the first minimum value deep."""
+    return get_first_value_deep(input_dictionary, min)
 
 
 def is_json(potential_json):
@@ -108,13 +128,17 @@ def get_word_diagnostic(word_count_dictionary):
     # create a diagnostics like "in the third paragraph" based on the dictionary
     # that contains the words counts in each of the paragraphs of a document
     if word_count_dictionary:
-        paragraph_number_details = get_first_minimum_value(word_count_dictionary)
+        paragraph_number_details_list = get_first_minimum_value_deep(
+            word_count_dictionary
+        )
+        filename_for_paragraph_number_details = paragraph_number_details_list[0]
+        paragraph_number_details = paragraph_number_details_list[1]
         paragraph_number = paragraph_number_details[0]
         paragraph_number_as_word = get_number_as_words(paragraph_number)
         paragraph_number_as_word_phrase = (
             constants.words.In_The + constants.markers.Space + paragraph_number_as_word
         )
-        return paragraph_number_as_word_phrase
+        return paragraph_number_as_word_phrase, filename_for_paragraph_number_details
     # since there are no paragraphs and no counts of words because the dictionary
     # is empty, return the empty string instead of a diagnostic phrase
     return constants.markers.Nothing

--- a/gator/util.py
+++ b/gator/util.py
@@ -141,7 +141,8 @@ def get_word_diagnostic(word_count_dictionary):
         return paragraph_number_as_word_phrase, filename_for_paragraph_number_details
     # since there are no paragraphs and no counts of words because the dictionary
     # is empty, return the empty string instead of a diagnostic phrase
-    return constants.markers.Nothing
+    # for both the paragraph number as word phrase and the filename
+    return constants.markers.Nothing, constants.markers.Nothing
 
 
 def get_file_diagnostic(file_count_dictionary):

--- a/gator/util.py
+++ b/gator/util.py
@@ -168,4 +168,4 @@ def get_file_diagnostic(file_count_dictionary):
         return file_name_phrase
     # since there are no file names and no counts of entities because the dictionary
     # is empty, return the "in a file" string instead of a diagnostic phrase
-    return constants.markers.File
+    return constants.markers.In_A_File

--- a/gator/util.py
+++ b/gator/util.py
@@ -57,6 +57,19 @@ def get_symbol_answer(boolean_value):
     return "✘"
 
 
+def flatten_dictionary_values(input_dictionary):
+    """Flatten by extracting the value from the dictionary that is a value."""
+    flat_dictionary = {}
+    for filename, file_count_dictionary in input_dictionary.items():
+        # the internal dictionary will have a single key,value pair
+        # extract the value and then store it in the flat_dictionary
+        for key in file_count_dictionary:
+            extracted_value = file_count_dictionary[key]
+            flat_dictionary[filename] = extracted_value
+            break
+    return flat_dictionary
+
+
 def get_first_value_deep(input_dictionary, finder=min):
     """Return all deep values matched by a finder function."""
     filename_count_dictionary = {}

--- a/gator/util.py
+++ b/gator/util.py
@@ -63,10 +63,9 @@ def flatten_dictionary_values(input_dictionary):
     for filename, file_count_dictionary in input_dictionary.items():
         # the internal dictionary will have a single key,value pair
         # extract the value and then store it in the flat_dictionary
-        for key in file_count_dictionary:
-            extracted_value = file_count_dictionary[key]
-            flat_dictionary[filename] = extracted_value
-            break
+        key = next(iter(file_count_dictionary))
+        extracted_value = file_count_dictionary[key]
+        flat_dictionary[filename] = extracted_value
     return flat_dictionary
 
 

--- a/gator/util.py
+++ b/gator/util.py
@@ -58,7 +58,7 @@ def get_symbol_answer(boolean_value):
 
 
 def get_first_value_deep(input_dictionary, finder=min):
-    """Iteratively return deep values matched by a finder function."""
+    """Return all deep values matched by a finder function."""
     filename_count_dictionary = {}
     for filename, paragraph_count_dictionary in input_dictionary.items():
         filename_minimum = get_first_value(paragraph_count_dictionary, finder)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -21,6 +21,7 @@ def test_markers_constant_defined():
     assert constants.markers.Nothing == ""
     assert constants.markers.Space == " "
     assert constants.markers.File == "in a file"
+    assert constants.markers.First == 1
     assert constants.markers.Invalid == -1
 
 
@@ -120,6 +121,8 @@ def test_markers_constant_cannot_redefine():
         constants.markers.Tab = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):
         constants.markers.File = CANNOT_SET_CONSTANT_VARIABLE
+    with pytest.raises(AttributeError):
+        constants.markers.First = 1
     with pytest.raises(AttributeError):
         constants.markers.Invalid = 10
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -20,8 +20,9 @@ def test_markers_constant_defined():
     assert constants.markers.No_Diagnostic == ""
     assert constants.markers.Nothing == ""
     assert constants.markers.Space == " "
+    assert constants.markers.In_A_File == "in a file"
     assert constants.markers.Of_File == "of file"
-    assert constants.markers.File == "in a file"
+    assert constants.markers.File == "file"
     assert constants.markers.First == 1
     assert constants.markers.Invalid == -1
 
@@ -122,6 +123,8 @@ def test_markers_constant_cannot_redefine():
         constants.markers.Tab = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):
         constants.markers.Of_File = CANNOT_SET_CONSTANT_VARIABLE
+    with pytest.raises(AttributeError):
+        constants.markers.In_A_File = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):
         constants.markers.File = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -20,6 +20,7 @@ def test_markers_constant_defined():
     assert constants.markers.No_Diagnostic == ""
     assert constants.markers.Nothing == ""
     assert constants.markers.Space == " "
+    assert constants.markers.Of_File == "of file"
     assert constants.markers.File == "in a file"
     assert constants.markers.First == 1
     assert constants.markers.Invalid == -1
@@ -119,6 +120,8 @@ def test_markers_constant_cannot_redefine():
         constants.markers.Space = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):
         constants.markers.Tab = CANNOT_SET_CONSTANT_VARIABLE
+    with pytest.raises(AttributeError):
+        constants.markers.Of_File = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):
         constants.markers.File = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -97,6 +97,11 @@ def test_environmentvariables_constant_defined():
     assert constants.environmentvariables.Home == "GATORGRADER_HOME"
 
 
+def test_functions_constant_defined():
+    """Check correctness for the variables in the functions constant."""
+    assert constants.functions.Count_Total_Words == "count_total_words"
+
+
 def test_languages_constant_cannot_redefine():
     """Check cannot redefine the variables in the languages constant."""
     with pytest.raises(AttributeError):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -86,7 +86,7 @@ def test_one_glob_case_sensitive_handling(tmpdir):
         assert len(created_paths) == 2
 
 
-def test_garbage_glob_returns_no_matching_paths(tmpdir):
+def test_garbage_glob_file_returns_no_matching_paths(tmpdir):
     """Ensure that creating a garbage globbed path returns no matches."""
     hello_file_one = tmpdir.join("hello1.txt")
     hello_file_one.write("content")
@@ -97,10 +97,18 @@ def test_garbage_glob_returns_no_matching_paths(tmpdir):
         files.create_paths(tmpdir.basename, file="FAKE&&&FDF$$#**", home=tmpdir.dirname)
     )
     assert len(created_paths) == 0
-    for created_path in files.create_paths(
-        tmpdir.basename, file="FAKE&&&FDF$$#**", home=tmpdir.dirname
-    ):
-        assert ".txt" in str(created_path)
+
+
+def test_garbage_glob_ext_returns_no_matching_paths(tmpdir):
+    """Ensure that creating a garbage globbed path returns no matches."""
+    hello_file_one = tmpdir.join("hello1.txt")
+    hello_file_one.write("content")
+    hello_file_two = tmpdir.join("hello2.txt")
+    hello_file_two.write("content")
+    assert len(tmpdir.listdir()) == 2
+    created_paths = list(
+        files.create_paths(tmpdir.basename, file="*.FAKE", home=tmpdir.dirname)
+    )
     assert len(created_paths) == 0
 
 

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -354,7 +354,7 @@ def test_perform_actions_display_welcome_and_ready_check_regex_file(
     counted_newlines = captured.out.count("\n")
     assert "GatorGrader" in captured.out
     assert "regular expression" in captured.out
-    assert "Found 0 matches" in captured.out
+    assert "Found 0 match(es)" in captured.out
     assert counted_newlines == 7
     assert exit_code == 1
 
@@ -401,7 +401,7 @@ def test_perform_actions_display_welcome_and_ready_check_regex_command(
     counted_newlines = captured.out.count("\n")
     assert "GatorGrader" in captured.out
     assert "regular expression" in captured.out
-    assert "Found 0 matches" in captured.out
+    assert "Found 0 match(es)" in captured.out
     assert counted_newlines == 7
     assert exit_code == 1
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -143,7 +143,6 @@ def test_flatten_dictionary():
         "repository.py": {1: 18},
     }
     flat_input_dictionary = util.flatten_dictionary_values(input_dictionary)
-    print(flat_input_dictionary)
     assert flat_input_dictionary["leave.py"] == 4
     assert flat_input_dictionary["run.py"] == 8
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -237,7 +237,7 @@ def test_word_diagnostic_empty_dictionary():
     """Check to see if diagnostic is produced with an empty dictionary."""
     word_count_dictionary = {}
     word_diagnostic = util.get_word_diagnostic(word_count_dictionary)
-    assert word_diagnostic == ""
+    assert word_diagnostic == ("", "")
 
 
 def test_find_minimum_in_dictionary_single_max_deep():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -236,3 +236,153 @@ def test_word_diagnostic_empty_dictionary():
     word_count_dictionary = {}
     word_diagnostic = util.get_word_diagnostic(word_count_dictionary)
     assert word_diagnostic == ""
+
+
+def test_find_minimum_in_dictionary_single_max_deep():
+    """Check if the maximum value is found in a dictionary deep."""
+    input_file_one = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43}
+    input_file_two = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 43}
+    input_file_three = {"John": 21, "Mike": 52, "Sarah": 12, "Bob": 1}
+    outer_dictionary = {
+        "input_file_one": input_file_one,
+        "input_file_two": input_file_two,
+        "input_file_three": input_file_three,
+    }
+    util.get_first_value_deep(outer_dictionary, finder=min)
+
+
+def test_find_minimum_in_dictionary_single_max_deep_words():
+    """Check to see if diagnostic is produced with a single minimum value."""
+    input_file_one = {1: 10, 2: 5, 3: 4}
+    input_file_two = {1: 10, 2: 5, 3: 4}
+    input_file_three = {1: 10, 2: 5, 3: 1}
+    outer_dictionary = {
+        "input_file_one": input_file_one,
+        "input_file_two": input_file_two,
+        "input_file_three": input_file_three,
+    }
+    util.get_first_value_deep(outer_dictionary, finder=min)
+
+
+def test_find_minimum_in_dictionary_single_max_deep_words_diagnostic():
+    """Check to see if diagnostic is produced with a single minimum value."""
+    input_file_one = {1: 10, 2: 5, 3: 4}
+    input_file_two = {1: 10, 2: 5, 3: 4}
+    input_file_three = {1: 10, 2: 5, 3: 1}
+    outer_dictionary = {
+        "input_file_one": input_file_one,
+        "input_file_two": input_file_two,
+        "input_file_three": input_file_three,
+    }
+    util.get_word_diagnostic(outer_dictionary)
+
+
+def test_find_minimum_in_dictionary_single_max_deep_words_diagnostic_realistic():
+    """Check to see if diagnostic is produced with a single minimum value."""
+    outer_dictionary = {
+        "README.md": {
+            1: 3,
+            2: 12,
+            3: 82,
+            4: 2,
+            5: 152,
+            6: 51,
+            7: 68,
+            8: 66,
+            9: 104,
+            10: 1,
+            11: 53,
+            12: 102,
+            13: 59,
+            14: 47,
+            15: 98,
+            16: 123,
+            17: 34,
+            18: 42,
+            19: 108,
+            20: 8,
+            21: 11,
+        },
+        "LICENSE.md": {
+            1: 29,
+            2: 17,
+            3: 98,
+            4: 77,
+            5: 45,
+            6: 55,
+            7: 35,
+            8: 49,
+            9: 112,
+            10: 64,
+            11: 11,
+            12: 12,
+            13: 16,
+            14: 25,
+            15: 50,
+            16: 15,
+            17: 58,
+            18: 36,
+            19: 90,
+            20: 27,
+            21: 41,
+            22: 118,
+            23: 124,
+            24: 19,
+            25: 14,
+            26: 76,
+            27: 113,
+            28: 22,
+            29: 41,
+            30: 70,
+            31: 76,
+            32: 25,
+            33: 39,
+            34: 101,
+            35: 38,
+            36: 30,
+            37: 136,
+            38: 67,
+            39: 109,
+            40: 76,
+            41: 46,
+            42: 85,
+            43: 69,
+            44: 34,
+            45: 96,
+            46: 42,
+            47: 26,
+            48: 47,
+            49: 58,
+            50: 60,
+            51: 50,
+            52: 88,
+            53: 41,
+            54: 96,
+            55: 77,
+            56: 34,
+            57: 83,
+            58: 36,
+            59: 63,
+            60: 148,
+            61: 73,
+            62: 163,
+            63: 30,
+            64: 110,
+            65: 84,
+            66: 44,
+            67: 83,
+            68: 40,
+            69: 33,
+            70: 88,
+            71: 105,
+            72: 61,
+            73: 41,
+            74: 51,
+            75: 13,
+            76: 21,
+            77: 36,
+            78: 46,
+            79: 65,
+        },
+    }
+    util.get_word_diagnostic(outer_dictionary)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -250,11 +250,13 @@ def test_find_minimum_in_dictionary_single_max_deep():
         "input_file_two": input_file_two,
         "input_file_three": input_file_three,
     }
-    util.get_first_maximum_value_deep(outer_dictionary)
+    found = util.get_first_maximum_value_deep(outer_dictionary)
+    assert found[0] == "input_file_one"
+    assert found[1] == ("Mike", 52)
 
 
 def test_find_minimum_in_dictionary_single_max_deep_words():
-    """Check to see if diagnostic is produced with a single minimum value."""
+    """Check if the minimum value is found in a dictionary deep."""
     input_file_one = {1: 10, 2: 5, 3: 4}
     input_file_two = {1: 10, 2: 5, 3: 4}
     input_file_three = {1: 10, 2: 5, 3: 1}
@@ -263,7 +265,9 @@ def test_find_minimum_in_dictionary_single_max_deep_words():
         "input_file_two": input_file_two,
         "input_file_three": input_file_three,
     }
-    util.get_first_minimum_value_deep(outer_dictionary)
+    found = util.get_first_minimum_value_deep(outer_dictionary)
+    assert found[0] == "input_file_three"
+    assert found[1] == (3, 1)
 
 
 def test_find_minimum_in_dictionary_single_max_deep_words_diagnostic():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -250,7 +250,7 @@ def test_find_minimum_in_dictionary_single_max_deep():
         "input_file_two": input_file_two,
         "input_file_three": input_file_three,
     }
-    util.get_first_value_deep(outer_dictionary, finder=min)
+    util.get_first_maximum_value_deep(outer_dictionary)
 
 
 def test_find_minimum_in_dictionary_single_max_deep_words():
@@ -263,7 +263,7 @@ def test_find_minimum_in_dictionary_single_max_deep_words():
         "input_file_two": input_file_two,
         "input_file_three": input_file_three,
     }
-    util.get_first_value_deep(outer_dictionary, finder=min)
+    util.get_first_minimum_value_deep(outer_dictionary)
 
 
 def test_find_minimum_in_dictionary_single_max_deep_words_diagnostic():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -122,6 +122,53 @@ def test_json_detection_not_found():
     assert is_valid_json is False
 
 
+def test_relational_operator_exacted_true_not_exacted():
+    """Check to see if the exacted relational operator returns True, no exacting."""
+    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10)
+    assert relation_boolean is True
+    assert relation_value == 100
+    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10, False)
+    assert relation_boolean is True
+    assert relation_value == 100
+
+
+def test_relational_operator_exacted_true_exacted():
+    """Check to see if the exacted relational operator returns True."""
+    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 100, True)
+    assert relation_boolean is True
+    assert relation_value == 100
+
+
+def test_relational_operator_exacted_false_not_exacted():
+    """Check to see if the exacted relational operator returns False, no exacting."""
+    relation_boolean, relation_value = util.greater_than_equal_exacted(10, 100)
+    assert relation_boolean is False
+    assert relation_value == 10
+    relation_boolean, relation_value = util.greater_than_equal_exacted(10, 100, False)
+    assert relation_boolean is False
+    assert relation_value == 10
+
+
+def test_relational_operator_exacted_false_exacted():
+    """Check to see if the exacted relational operator returns False."""
+    relation_boolean, relation_value = util.greater_than_equal_exacted(10, 100, True)
+    assert relation_boolean is False
+    assert relation_value == 10
+    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10, True)
+    assert relation_boolean is False
+    assert relation_value == 100
+
+
+def test_number_to_words_ordinal_and_cardinal():
+    """Check to see if numbers can be converted to ordinal or cardinal words."""
+    # note that ordinal is the default
+    number_as_word = util.get_number_as_words(42)
+    assert number_as_word == "forty-second"
+    # it is also possible to request cardinal words
+    number_as_word = util.get_number_as_words(42, constants.words.Cardinal)
+    assert number_as_word == "forty-two"
+
+
 def test_find_in_empty_dictionary_min():
     """Check if the None value is found in an empty dictionary."""
     input = {}
@@ -168,53 +215,6 @@ def test_find_minimum_in_dictionary_multiple_min():
     found_values = util.get_first_minimum_value(input)
     assert found_values[0] == "Sarah"
     assert found_values[1] == 12
-
-
-def test_relational_operator_exacted_true_not_exacted():
-    """Check to see if the exacted relational operator returns True, no exacting."""
-    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10)
-    assert relation_boolean is True
-    assert relation_value == 100
-    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10, False)
-    assert relation_boolean is True
-    assert relation_value == 100
-
-
-def test_relational_operator_exacted_true_exacted():
-    """Check to see if the exacted relational operator returns True."""
-    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 100, True)
-    assert relation_boolean is True
-    assert relation_value == 100
-
-
-def test_relational_operator_exacted_false_not_exacted():
-    """Check to see if the exacted relational operator returns False, no exacting."""
-    relation_boolean, relation_value = util.greater_than_equal_exacted(10, 100)
-    assert relation_boolean is False
-    assert relation_value == 10
-    relation_boolean, relation_value = util.greater_than_equal_exacted(10, 100, False)
-    assert relation_boolean is False
-    assert relation_value == 10
-
-
-def test_relational_operator_exacted_false_exacted():
-    """Check to see if the exacted relational operator returns False."""
-    relation_boolean, relation_value = util.greater_than_equal_exacted(10, 100, True)
-    assert relation_boolean is False
-    assert relation_value == 10
-    relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10, True)
-    assert relation_boolean is False
-    assert relation_value == 100
-
-
-def test_number_to_words_ordinal_and_cardinal():
-    """Check to see if numbers can be converted to ordinal or cardinal words."""
-    # note that ordinal is the default
-    number_as_word = util.get_number_as_words(42)
-    assert number_as_word == "forty-second"
-    # it is also possible to request cardinal words
-    number_as_word = util.get_number_as_words(42, constants.words.Cardinal)
-    assert number_as_word == "forty-two"
 
 
 def test_word_diagnostic_single_min_first():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -219,16 +219,18 @@ def test_find_minimum_in_dictionary_multiple_min():
 
 def test_word_diagnostic_single_min_first():
     """Check to see if diagnostic is produced with a single minimum value."""
-    word_count_dictionary = {1: 4, 2: 5, 3: 10}
+    word_count_dictionary_file_one = {1: 4, 2: 5, 3: 10}
+    word_count_dictionary = {"file_one": word_count_dictionary_file_one}
     word_diagnostic = util.get_word_diagnostic(word_count_dictionary)
-    assert word_diagnostic == "in the first"
+    assert word_diagnostic[0] == "in the first"
 
 
 def test_word_diagnostic_single_min_last():
     """Check to see if diagnostic is produced with a single minimum value."""
-    word_count_dictionary = {1: 10, 2: 5, 3: 4}
+    word_count_dictionary_file_one = {1: 10, 2: 5, 3: 4}
+    word_count_dictionary = {"file_one": word_count_dictionary_file_one}
     word_diagnostic = util.get_word_diagnostic(word_count_dictionary)
-    assert word_diagnostic == "in the third"
+    assert word_diagnostic[0] == "in the third"
 
 
 def test_word_diagnostic_empty_dictionary():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -122,6 +122,32 @@ def test_json_detection_not_found():
     assert is_valid_json is False
 
 
+def test_flatten_dictionary():
+    """Check to see if the dictionary is flattened correctly."""
+    input_dictionary = {
+        "leave.py": {1: 4},
+        "run.py": {1: 8},
+        "entities.py": {1: 18},
+        "files.py": {1: 33},
+        "display.py": {1: 0},
+        "util.py": {1: 26},
+        "markdown.py": {1: 6},
+        "__init__.py": {1: 0},
+        "arguments.py": {1: 107},
+        "comments.py": {1: 6},
+        "orchestrate.py": {1: 38},
+        "constants.py": {1: 28},
+        "report.py": {1: 19},
+        "invoke.py": {1: 89},
+        "fragments.py": {1: 68},
+        "repository.py": {1: 18},
+    }
+    flat_input_dictionary = util.flatten_dictionary_values(input_dictionary)
+    print(flat_input_dictionary)
+    assert flat_input_dictionary["leave.py"] == 4
+    assert flat_input_dictionary["run.py"] == 8
+
+
 def test_relational_operator_exacted_true_not_exacted():
     """Check to see if the exacted relational operator returns True, no exacting."""
     relation_boolean, relation_value = util.greater_than_equal_exacted(100, 10)


### PR DESCRIPTION
Currently you can specify a filename, but not a wildcard.


You can specify a wildcard, like `*.py` when looking for fragment.


- [X] Commit messages that are correctly formatted
- [X] Tests for newly introduced code
- [X] Docstrings for newly introduced code

This PR is a feature that fixes #98.


@gkapfham