### PR TITLE
Fix wording issue for CountCommits check

### DIFF
--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -32,10 +32,10 @@ def invoke_commits_check(student_repository, expected_count, exact=False):
     if not exact:
         # create a message for an "at least" because it is not exact
         # the "at least" check is the default, you must opt-in to an exact check
-        message = "Repository has at least " + str(expected_count) + " commit(s)"
+        message = "The repository has at least " + str(expected_count) + " commit(s)"
     else:
         # create a message for an exact check
-        message = "Repository has exactly " + str(expected_count) + " commit(s)"
+        message = "The repository has exactly " + str(expected_count) + " commit(s)"
     # diagnostic is created when repository does not have sufficient commits
     # call report_result to update report for this check
     diagnostic = "Found " + str(actual_count) + " commit(s) in the Git repository"


### PR DESCRIPTION
Updated to say "The repository has..." rather than "Repository has..." to match other content.

<!-- A short description can be included here -->
<!-- Please ensure that reviewers are assigned -->

### What is the current behavior?

Check displays text "Repository has" which does not match current format (i.e. it is missing a preceding "the" to start the statement). This PR is associated with the below issue:

https://github.com/GatorEducator/gatorgrader/issues/194

### What is the new behavior if this PR is merged?
Updated to say "The repository has..." to match current format

#### Other information

##### This PR has:

- [x] Commit messages that are correctly formatted
- [ ] Tests for newly introduced code
- [ ] Docstrings for newly introduced code

This PR is a small change that fixes #195 

<!-- We required the above line statement because GatorGrader uses: -->
<!-- https://github.com/Michionlion/pr-tag-release -->
<!-- to automatically generate a tag and a release from a merged PR -->

#### Developers
@ajciancimino

