### PR TITLE
WIP: Add the optional argument of --reach to certain checks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ requests = ">=2.20.0"
 commonmark = "*"
 num2words = "*"
 pluginbase = "*"
+black = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8e19182400c050d41763f276193e6e85662b7e4cbacd56da8d7b71ec9e6f7f45"
+            "sha256": "a464c16540a7e1cd387feb71df411da486c046abb3d95ab0fd72a4459faa30f8"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,28 @@
         ]
     },
     "default": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+            ],
+            "index": "pypi",
+            "version": "==19.10b0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
@@ -27,6 +49,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
         },
         "commonmark": {
             "hashes": [
@@ -72,12 +101,45 @@
             "index": "pypi",
             "version": "==0.5.10"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424",
+                "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"
+            ],
+            "version": "==0.7.0"
+        },
         "pluginbase": {
             "hashes": [
                 "sha256:497894df38d0db71e1a4fbbfaceb10c3ef49a3f95a0582e11b75f8adaa030005"
             ],
             "index": "pypi",
             "version": "==1.0.0"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:07b39bf943d3d2fe63d46281d8504f8df0ff3fe4c57e13d1656737950e53e525",
+                "sha256:0932941cdfb3afcbc26cc3bcf7c3f3d73d5a9b9c56955d432dbf8bbc147d4c5b",
+                "sha256:0e182d2f097ea8549a249040922fa2b92ae28be4be4895933e369a525ba36576",
+                "sha256:10671601ee06cf4dc1bc0b4805309040bb34c9af423c12c379c83d7895622bb5",
+                "sha256:23e2c2c0ff50f44877f64780b815b8fd2e003cda9ce817a7fd00dea5600c84a0",
+                "sha256:26ff99c980f53b3191d8931b199b29d6787c059f2e029b2b0c694343b1708c35",
+                "sha256:27429b8d74ba683484a06b260b7bb00f312e7c757792628ea251afdbf1434003",
+                "sha256:3e77409b678b21a056415da3a56abfd7c3ad03da71f3051bbcdb68cf44d3c34d",
+                "sha256:4e8f02d3d72ca94efc8396f8036c0d3bcc812aefc28ec70f35bb888c74a25161",
+                "sha256:4eae742636aec40cf7ab98171ab9400393360b97e8f9da67b1867a9ee0889b26",
+                "sha256:6a6ae17bf8f2d82d1e8858a47757ce389b880083c4ff2498dba17c56e6c103b9",
+                "sha256:6a6ba91b94427cd49cd27764679024b14a96874e0dc638ae6bdd4b1a3ce97be1",
+                "sha256:7bcd322935377abcc79bfe5b63c44abd0b29387f267791d566bbb566edfdd146",
+                "sha256:98b8ed7bb2155e2cbb8b76f627b2fd12cf4b22ab6e14873e8641f266e0fb6d8f",
+                "sha256:bd25bb7980917e4e70ccccd7e3b5740614f1c408a642c245019cff9d7d1b6149",
+                "sha256:d0f424328f9822b0323b3b6f2e4b9c90960b24743d220763c7f07071e0778351",
+                "sha256:d58e4606da2a41659c84baeb3cfa2e4c87a74cec89a1e7c56bee4b956f9d7461",
+                "sha256:e3cd21cc2840ca67de0bbe4071f79f031c81418deb544ceda93ad75ca1ee9f7b",
+                "sha256:e6c02171d62ed6972ca8631f6f34fa3281d51db8b326ee397b9c83093a6b7242",
+                "sha256:e7c7661f7276507bce416eaae22040fd91ca471b5b33c13f8ff21137ed6f248c",
+                "sha256:ecc6de77df3ef68fee966bb8cb4e067e84d4d1f397d0ef6fce46913663540d77"
+            ],
+            "version": "==2020.1.8"
         },
         "requests": {
             "hashes": [
@@ -94,12 +156,45 @@
             ],
             "version": "==2.0.5"
         },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.7"
+            "version": "==1.25.8"
         }
     },
     "develop": {
@@ -192,10 +287,10 @@
         },
         "colorama": {
             "hashes": [
-                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
-                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
             ],
-            "version": "==0.4.3"
+            "version": "==0.4.1"
         },
         "coverage": {
             "hashes": [
@@ -315,11 +410,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
-                "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "isort": {
             "hashes": [
@@ -370,10 +465,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39",
-                "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
             ],
-            "version": "==8.1.0"
+            "version": "==8.2.0"
         },
         "msgpack": {
             "hashes": [
@@ -398,10 +493,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb",
-                "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"
+                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
+                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
             ],
-            "version": "==20.0"
+            "version": "==20.1"
         },
         "pathspec": {
             "hashes": [
@@ -470,9 +565,9 @@
         },
         "pynvim": {
             "hashes": [
-                "sha256:71fd8bb3285deeda8c259383066214e0d522a96bfb3ca4871333adfcb454e9d6"
+                "sha256:55e918d664654cfa1c9889d3dbe7c63e9f338df5d49471663f78d54c85e84c58"
             ],
-            "version": "==0.4.0"
+            "version": "==0.4.1"
         },
         "pyparsing": {
             "hashes": [
@@ -483,11 +578,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:9f8d44f4722b3d06b41afaeb8d177cfbe0700f8351b1fc755dd27eedaa3eb9e0",
-                "sha256:f5d3d0e07333119fe7d4af4ce122362dc4053cdd34a71d2766290cf5369c64ad"
+                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
+                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
             ],
             "index": "pypi",
-            "version": "==5.3.3"
+            "version": "==5.3.5"
         },
         "pytest-cov": {
             "hashes": [
@@ -523,11 +618,11 @@
         },
         "radon": {
             "hashes": [
-                "sha256:20f799949e42e6899bc9304539de222d3bdaeec276f38fbd4034859ccd548b46",
-                "sha256:32ac2f86bfacbddade5c79f0e927e97f90a5cda5b86f880511dd849c4a0096e3"
+                "sha256:0c18111ec6cfe7f664bf9db6c51586714ac8c6d9741542706df8a85aca39b99a",
+                "sha256:56082c52206db45027d4a73612e1b21663c4cc2be3760fee769d966fd7efdd6d"
             ],
             "index": "pypi",
-            "version": "==4.0.0"
+            "version": "==4.1.0"
         },
         "regex": {
             "hashes": [
@@ -636,15 +731,14 @@
                 "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
-            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
             "version": "==1.4.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.7"
+            "version": "==1.25.8"
         },
         "wcwidth": {
             "hashes": [
@@ -669,10 +763,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:57147f6b0403b59f33fd357f169f860e031303415aeb7d04ede4839d23905ab8",
-                "sha256:7ae5ccaca427bafa9760ac3cd8f8c244bfc259794b5b6bb9db4dda2241575d09"
+                "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28",
+                "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
             ],
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         }
     }
 }

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -41,6 +41,14 @@ def get_parser():
     # Optional Named Checker Arguments {{{
 
     # None required for this checker
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default = False,
+        action = "store_true",
+    )
 
     # }}}
     return parser

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -73,5 +73,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if a command-line argument is not provided
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [invoke.invoke_file_in_directory_check(file, directory)]

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -73,5 +73,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if a command-line argument is not provided
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
-    reach = check_parsed_arguments.reach
-    return [invoke.invoke_file_in_directory_check(file, directory, reach)]
+    # reach = check_parsed_arguments.reach
+    return [invoke.invoke_file_in_directory_check(file, directory)]

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -73,5 +73,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if a command-line argument is not provided
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
-    # reach = check_parsed_arguments.reach
-    return [invoke.invoke_file_in_directory_check(file, directory)]
+    reach = check_parsed_arguments.reach
+    return [invoke.invoke_file_in_directory_check(file, directory, reach)]

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -74,4 +74,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_file_in_directory_check(file, directory, reach)]
+    return [invoke.invoke_file_in_directory_check(file, directory)]

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -73,4 +73,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if a command-line argument is not provided
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
+    reach = check_parsed_arguments.reach
     return [invoke.invoke_file_in_directory_check(file, directory, reach)]

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -40,6 +40,8 @@ def get_parser():
 
     # Optional Named Checker Arguments {{{
 
+    optional_group = parser.add_argument_group("optional check arguments")
+
     # None required for this checker
     # REACH: allows for a students to have a reach goal in their lab/practical
     # REQUIRED? No

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -73,4 +73,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if a command-line argument is not provided
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
-    return [invoke.invoke_file_in_directory_check(file, directory)]
+    return [invoke.invoke_file_in_directory_check(file, directory, reach)]

--- a/gator/checks/check_ConfirmFileExists.py
+++ b/gator/checks/check_ConfirmFileExists.py
@@ -46,8 +46,8 @@ def get_parser():
     optional_group.add_argument(
         "--reach",
         help="creates a higher goal for students to potentially reach",
-        default = False,
-        action = "store_true",
+        default=False,
+        action="store_true",
     )
 
     # }}}

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -82,5 +82,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     command = check_parsed_arguments.command
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_count_checks(command, count, exact)]
+    reach = check_parsed_arguments.reach
+    print(reach)
+    return [invoke.invoke_all_command_count_checks(command, count, exact, reach)]

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -55,8 +55,8 @@ def get_parser():
     optional_group.add_argument(
         "--reach",
         help="creates a higher goal for students to potentially reach",
-        default = False,
-        action = "store_true",
+        default=False,
+        action="store_true",
     )
 
     # }}}

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -83,5 +83,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    print(reach)
     return [invoke.invoke_all_command_count_checks(command, count, exact, reach)]

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -83,4 +83,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_count_checks(command, count, exact, reach)]
+    return [invoke.invoke_all_command_count_checks(command, count, exact)]

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -82,4 +82,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     command = check_parsed_arguments.command
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    return [invoke.invoke_all_command_count_checks(command, count, exact)]
+    return [invoke.invoke_all_command_count_checks(command, count, exact, reach)]

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -50,6 +50,15 @@ def get_parser():
         action="store_true",
     )
 
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default = False,
+        action = "store_true",
+    )
+
     # }}}
     return parser
 

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -82,4 +82,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     command = check_parsed_arguments.command
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [invoke.invoke_all_command_count_checks(command, count, exact, reach)]

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -23,7 +23,7 @@ def get_parser():
     # COMMAND: the command to execute
     # REQUIRED? Yes
     required_group.add_argument(
-        "--command", type=str, help="command to execute", required=True
+        "--command", type=str, metavar="CMD", help="command to execute", required=True
     )
 
     # COUNT: the number of lines of output

--- a/gator/checks/check_CountCommandOutput.py
+++ b/gator/checks/check_CountCommandOutput.py
@@ -82,5 +82,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     command = check_parsed_arguments.command
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [invoke.invoke_all_command_count_checks(command, count, exact)]

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -72,7 +72,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if the command-line argument is not provided
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
-        invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact)
+        invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact, reach)
     ]

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -74,5 +74,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
     return [
-        invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact, reach)
+        invoke.invoke_commits_check(
+            constants.paths.Current_Directory, count, exact, reach
+        )
     ]

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -41,14 +41,14 @@ def get_parser():
         default=False,
         action="store_true",
     )
-    
+
     # REACH: allows for a students to have a reach goal in their lab/practical
     # REQUIRED? No
     optional_group.add_argument(
         "--reach",
         help="creates a higher goal for students to potentially reach",
-        default = False,
-        action = "store_true",
+        default=False,
+        action="store_true",
     )
 
     # }}}

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -72,7 +72,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if the command-line argument is not provided
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact)
     ]

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -41,6 +41,15 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default = False,
+        action = "store_true",
+    )
 
     # }}}
     return parser

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -73,5 +73,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
     return [
-        invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact)
+        invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact, reach)
     ]

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -74,5 +74,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
     return [
-        invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact, reach)
+        invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact)
     ]

--- a/gator/checks/check_CountCommits.py
+++ b/gator/checks/check_CountCommits.py
@@ -72,6 +72,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # point since argparse will exit the program if the command-line argument is not provided
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_commits_check(constants.paths.Current_Directory, count, exact, reach)
     ]

--- a/gator/checks/check_CountFileLines.py
+++ b/gator/checks/check_CountFileLines.py
@@ -94,6 +94,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_count_checks(
-            count, file, directory, constants.markers.Nothing, exact, reach
+            count, file, directory, constants.markers.Nothing, exact
         )
     ]

--- a/gator/checks/check_CountFileLines.py
+++ b/gator/checks/check_CountFileLines.py
@@ -91,9 +91,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_count_checks(
-            count, file, directory, constants.markers.Nothing, exact
+            count, file, directory, constants.markers.Nothing, exact, reach
         )
     ]

--- a/gator/checks/check_CountFileLines.py
+++ b/gator/checks/check_CountFileLines.py
@@ -57,6 +57,14 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default = False,
+        action = "store_true",
+    )
 
     # }}}
     return parser
@@ -83,8 +91,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_count_checks(
-            count, file, directory, constants.markers.Nothing, exact
+            count, file, directory, constants.markers.Nothing, exact, reach
         )
     ]

--- a/gator/checks/check_CountFileLines.py
+++ b/gator/checks/check_CountFileLines.py
@@ -62,8 +62,8 @@ def get_parser():
     optional_group.add_argument(
         "--reach",
         help="creates a higher goal for students to potentially reach",
-        default = False,
-        action = "store_true",
+        default=False,
+        action="store_true",
     )
 
     # }}}

--- a/gator/checks/check_CountFileLines.py
+++ b/gator/checks/check_CountFileLines.py
@@ -91,7 +91,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_count_checks(
             count, file, directory, constants.markers.Nothing, exact

--- a/gator/checks/check_CountFileParagraphs.py
+++ b/gator/checks/check_CountFileParagraphs.py
@@ -91,4 +91,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    return [invoke.invoke_all_paragraph_checks(file, directory, count, exact)]
+    return [invoke.invoke_all_paragraph_checks(file, directory, count, exact, reach)]

--- a/gator/checks/check_CountFileParagraphs.py
+++ b/gator/checks/check_CountFileParagraphs.py
@@ -91,5 +91,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [invoke.invoke_all_paragraph_checks(file, directory, count, exact)]

--- a/gator/checks/check_CountFileParagraphs.py
+++ b/gator/checks/check_CountFileParagraphs.py
@@ -91,4 +91,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [invoke.invoke_all_paragraph_checks(file, directory, count, exact, reach)]

--- a/gator/checks/check_CountFileParagraphs.py
+++ b/gator/checks/check_CountFileParagraphs.py
@@ -57,6 +57,15 @@ def get_parser():
         action="store_true",
     )
 
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
+
     # }}}
     return parser
 

--- a/gator/checks/check_CountFileParagraphs.py
+++ b/gator/checks/check_CountFileParagraphs.py
@@ -92,4 +92,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_paragraph_checks(file, directory, count, exact, reach)]
+    return [invoke.invoke_all_paragraph_checks(file, directory, count, exact)]

--- a/gator/checks/check_CountFileParagraphs.py
+++ b/gator/checks/check_CountFileParagraphs.py
@@ -91,5 +91,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_paragraph_checks(file, directory, count, exact)]
+    reach = check_parsed_arguments.reach
+    return [invoke.invoke_all_paragraph_checks(file, directory, count, exact, reach)]

--- a/gator/checks/check_CountFileWords.py
+++ b/gator/checks/check_CountFileWords.py
@@ -95,7 +95,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_total_word_count_checks(
             file,

--- a/gator/checks/check_CountFileWords.py
+++ b/gator/checks/check_CountFileWords.py
@@ -95,7 +95,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_total_word_count_checks(
             file,
@@ -104,5 +104,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_total_words,
             constants.words.Total,
             exact,
+            reach
         )
     ]

--- a/gator/checks/check_CountFileWords.py
+++ b/gator/checks/check_CountFileWords.py
@@ -104,6 +104,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_total_words,
             constants.words.Total,
             exact,
-            reach
+            reach,
         )
     ]

--- a/gator/checks/check_CountFileWords.py
+++ b/gator/checks/check_CountFileWords.py
@@ -104,6 +104,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_total_words,
             constants.words.Total,
             exact,
-            reach,
         )
     ]

--- a/gator/checks/check_CountFileWords.py
+++ b/gator/checks/check_CountFileWords.py
@@ -66,8 +66,8 @@ def get_parser():
     optional_group.add_argument(
         "--reach",
         help="creates a higher goal for students to potentially reach",
-        default = False,
-        action = "store_true",
+        default=False,
+        action="store_true",
     )
 
     # }}}

--- a/gator/checks/check_CountFileWords.py
+++ b/gator/checks/check_CountFileWords.py
@@ -61,6 +61,14 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default = False,
+        action = "store_true",
+    )
 
     # }}}
     return parser
@@ -87,6 +95,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_total_word_count_checks(
             file,
@@ -95,5 +104,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_total_words,
             constants.words.Total,
             exact,
+            reach,
         )
     ]

--- a/gator/checks/check_CountMarkdownTags.py
+++ b/gator/checks/check_CountMarkdownTags.py
@@ -112,5 +112,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact)]

--- a/gator/checks/check_CountMarkdownTags.py
+++ b/gator/checks/check_CountMarkdownTags.py
@@ -112,4 +112,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact, reach)]

--- a/gator/checks/check_CountMarkdownTags.py
+++ b/gator/checks/check_CountMarkdownTags.py
@@ -66,6 +66,16 @@ def get_parser():
         action="store_true",
     )
 
+    # None required for this checker
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
+
     # }}}
 
     # add an epilog to list some of the available tags
@@ -102,4 +112,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact)]
+    return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact, reach)]

--- a/gator/checks/check_CountMarkdownTags.py
+++ b/gator/checks/check_CountMarkdownTags.py
@@ -112,5 +112,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact)]
+    reach = check_parsed_arguments.reach
+    return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact, reach)]

--- a/gator/checks/check_CountMarkdownTags.py
+++ b/gator/checks/check_CountMarkdownTags.py
@@ -113,4 +113,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact, reach)]
+    return [
+        invoke.invoke_all_markdown_checks(tag, count, file, directory, exact, reach)
+    ]

--- a/gator/checks/check_CountMarkdownTags.py
+++ b/gator/checks/check_CountMarkdownTags.py
@@ -113,4 +113,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact, reach)]
+    return [invoke.invoke_all_markdown_checks(tag, count, file, directory, exact)]

--- a/gator/checks/check_CountMultipleLineComments.py
+++ b/gator/checks/check_CountMultipleLineComments.py
@@ -111,6 +111,12 @@ def act(main_parsed_arguments, check_remaining_arguments):
     reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Multiple_Line, language, exact, reach
+            file,
+            directory,
+            count,
+            constants.comments.Multiple_Line,
+            language,
+            exact,
+            reach,
         )
     ]

--- a/gator/checks/check_CountMultipleLineComments.py
+++ b/gator/checks/check_CountMultipleLineComments.py
@@ -108,9 +108,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     language = check_parsed_arguments.language
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Multiple_Line, language, exact
+            file, directory, count, constants.comments.Multiple_Line, language, exact, reach
         )
     ]

--- a/gator/checks/check_CountMultipleLineComments.py
+++ b/gator/checks/check_CountMultipleLineComments.py
@@ -70,13 +70,15 @@ def get_parser():
         default=False,
         action="store_true",
     )
+
+    # None required for this checker
     # REACH: allows for a students to have a reach goal in their lab/practical
     # REQUIRED? No
     optional_group.add_argument(
-        "--advanced",
+        "--reach",
         help="creates a higher goal for students to potentially reach",
-        default = False,
-        action = "store_true",
+        default=False,
+        action="store_true",
     )
 
     # }}}

--- a/gator/checks/check_CountMultipleLineComments.py
+++ b/gator/checks/check_CountMultipleLineComments.py
@@ -111,6 +111,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Multiple_Line, language, exact, reach
+            file, directory, count, constants.comments.Multiple_Line, language, exact
         )
     ]

--- a/gator/checks/check_CountMultipleLineComments.py
+++ b/gator/checks/check_CountMultipleLineComments.py
@@ -70,6 +70,14 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--advanced",
+        help="creates a higher goal for students to potentially reach",
+        default = False,
+        action = "store_true",
+    )
 
     # }}}
     return parser
@@ -98,8 +106,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     language = check_parsed_arguments.language
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Multiple_Line, language, exact
+            file, directory, count, constants.comments.Multiple_Line, language, exact, reach
         )
     ]

--- a/gator/checks/check_CountMultipleLineComments.py
+++ b/gator/checks/check_CountMultipleLineComments.py
@@ -108,7 +108,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     language = check_parsed_arguments.language
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
             file, directory, count, constants.comments.Multiple_Line, language, exact

--- a/gator/checks/check_CountParagraphWords.py
+++ b/gator/checks/check_CountParagraphWords.py
@@ -106,6 +106,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_minimum_words,
             constants.words.Minimum,
             exact,
-            reach,
         )
     ]

--- a/gator/checks/check_CountParagraphWords.py
+++ b/gator/checks/check_CountParagraphWords.py
@@ -62,6 +62,16 @@ def get_parser():
         action="store_true",
     )
 
+    # None required for this checker
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
+
     # }}}
     return parser
 
@@ -95,5 +105,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_minimum_words,
             constants.words.Minimum,
             exact,
+            reach,
         )
     ]

--- a/gator/checks/check_CountParagraphWords.py
+++ b/gator/checks/check_CountParagraphWords.py
@@ -97,7 +97,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_minimum_word_count_checks(
             file,

--- a/gator/checks/check_CountParagraphWords.py
+++ b/gator/checks/check_CountParagraphWords.py
@@ -97,6 +97,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_minimum_word_count_checks(
             file,

--- a/gator/checks/check_CountParagraphWords.py
+++ b/gator/checks/check_CountParagraphWords.py
@@ -97,7 +97,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_minimum_word_count_checks(
             file,
@@ -106,5 +106,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_minimum_words,
             constants.words.Minimum,
             exact,
+            reach
         )
     ]

--- a/gator/checks/check_CountParagraphWords.py
+++ b/gator/checks/check_CountParagraphWords.py
@@ -106,6 +106,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
             fragments.count_minimum_words,
             constants.words.Minimum,
             exact,
-            reach
+            reach,
         )
     ]

--- a/gator/checks/check_CountSingleLineComments.py
+++ b/gator/checks/check_CountSingleLineComments.py
@@ -105,7 +105,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     language = check_parsed_arguments.language
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
             file, directory, count, constants.comments.Single_Line, language, exact

--- a/gator/checks/check_CountSingleLineComments.py
+++ b/gator/checks/check_CountSingleLineComments.py
@@ -108,6 +108,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Single_Line, language, exact, reach
+            file, directory, count, constants.comments.Single_Line, language, exact
         )
     ]

--- a/gator/checks/check_CountSingleLineComments.py
+++ b/gator/checks/check_CountSingleLineComments.py
@@ -69,6 +69,14 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
 
     # }}}
     return parser
@@ -97,8 +105,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     language = check_parsed_arguments.language
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Single_Line, language, exact
+            file, directory, count, constants.comments.Single_Line, language, exact, reach
         )
     ]

--- a/gator/checks/check_CountSingleLineComments.py
+++ b/gator/checks/check_CountSingleLineComments.py
@@ -105,9 +105,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     directory = check_parsed_arguments.directory
     language = check_parsed_arguments.language
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Single_Line, language, exact
+            file, directory, count, constants.comments.Single_Line, language, exact, reach
         )
     ]

--- a/gator/checks/check_CountSingleLineComments.py
+++ b/gator/checks/check_CountSingleLineComments.py
@@ -108,6 +108,12 @@ def act(main_parsed_arguments, check_remaining_arguments):
     reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_comment_checks(
-            file, directory, count, constants.comments.Single_Line, language, exact, reach
+            file,
+            directory,
+            count,
+            constants.comments.Single_Line,
+            language,
+            exact,
+            reach,
         )
     ]

--- a/gator/checks/check_ExecuteCommand.py
+++ b/gator/checks/check_ExecuteCommand.py
@@ -23,7 +23,7 @@ def get_parser():
     # COMMAND: the command to execute
     # REQUIRED? Yes
     required_group.add_argument(
-        "--command", type=str, help="command to execute", required=True
+        "--command", type=str, metavar="CMD", help="command to execute", required=True
     )
 
     # }}}

--- a/gator/checks/check_ExecuteCommand.py
+++ b/gator/checks/check_ExecuteCommand.py
@@ -31,6 +31,16 @@ def get_parser():
     # Optional Named Checker Arguments {{{
 
     # None required for this checker
+    optional_group = parser.add_argument_group("optional check arguments")
+    # None required for this checker
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
 
     # }}}
     return parser

--- a/gator/checks/check_ExecuteCommand.py
+++ b/gator/checks/check_ExecuteCommand.py
@@ -61,5 +61,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # This means that the use of check_ExecuteCommand would have already failed by this
     # point since argparse will exit the program if a command-line argument is not provided
     command = check_parsed_arguments.command
-    reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_executes_checks(command, reach)]
+    # reach = check_parsed_arguments.reach
+    return [invoke.invoke_all_command_executes_checks(command)]

--- a/gator/checks/check_ExecuteCommand.py
+++ b/gator/checks/check_ExecuteCommand.py
@@ -61,4 +61,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     # This means that the use of check_ExecuteCommand would have already failed by this
     # point since argparse will exit the program if a command-line argument is not provided
     command = check_parsed_arguments.command
-    return [invoke.invoke_all_command_executes_checks(command)]
+    reach = check_parsed_arguments.reach
+    return [invoke.invoke_all_command_executes_checks(command, reach)]

--- a/gator/checks/check_ListChecks.py
+++ b/gator/checks/check_ListChecks.py
@@ -36,7 +36,6 @@ def get_parser():
         type=str,
     )
 
-
     optional_group.add_argument(
         "--reach",
         help="creates a higher goal for students to potentially reach",

--- a/gator/checks/check_ListChecks.py
+++ b/gator/checks/check_ListChecks.py
@@ -36,6 +36,14 @@ def get_parser():
         type=str,
     )
 
+
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
+
     # }}}
     return parser
 

--- a/gator/checks/check_MatchCommandFragment.py
+++ b/gator/checks/check_MatchCommandFragment.py
@@ -90,4 +90,8 @@ def act(main_parsed_arguments, check_remaining_arguments):
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact, reach)]
+    return [
+        invoke.invoke_all_command_fragment_checks(
+            command, fragment, count, exact, reach
+        )
+    ]

--- a/gator/checks/check_MatchCommandFragment.py
+++ b/gator/checks/check_MatchCommandFragment.py
@@ -57,6 +57,13 @@ def get_parser():
         action="store_true",
     )
 
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
+
     # }}}
     return parser
 
@@ -82,4 +89,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     fragment = check_parsed_arguments.fragment
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact)]
+    return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact, reach)]

--- a/gator/checks/check_MatchCommandFragment.py
+++ b/gator/checks/check_MatchCommandFragment.py
@@ -89,4 +89,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     fragment = check_parsed_arguments.fragment
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact, reach)]

--- a/gator/checks/check_MatchCommandFragment.py
+++ b/gator/checks/check_MatchCommandFragment.py
@@ -89,5 +89,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     fragment = check_parsed_arguments.fragment
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact)]

--- a/gator/checks/check_MatchCommandFragment.py
+++ b/gator/checks/check_MatchCommandFragment.py
@@ -89,5 +89,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     fragment = check_parsed_arguments.fragment
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact)]
+    reach = check_parsed_arguments.reach
+    return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact, reach)]

--- a/gator/checks/check_MatchCommandFragment.py
+++ b/gator/checks/check_MatchCommandFragment.py
@@ -90,4 +90,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact, reach)]
+    return [invoke.invoke_all_command_fragment_checks(command, fragment, count, exact)]

--- a/gator/checks/check_MatchCommandRegex.py
+++ b/gator/checks/check_MatchCommandRegex.py
@@ -88,5 +88,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     regex = check_parsed_arguments.regex
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact)]
+    reach = check_parsed_arguments.reach
+    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact, reach)]

--- a/gator/checks/check_MatchCommandRegex.py
+++ b/gator/checks/check_MatchCommandRegex.py
@@ -88,5 +88,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     regex = check_parsed_arguments.regex
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [invoke.invoke_all_command_regex_checks(command, regex, count, exact)]

--- a/gator/checks/check_MatchCommandRegex.py
+++ b/gator/checks/check_MatchCommandRegex.py
@@ -88,5 +88,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     regex = check_parsed_arguments.regex
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact, reach)]
+    # reach = check_parsed_arguments.reach
+    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact)]

--- a/gator/checks/check_MatchCommandRegex.py
+++ b/gator/checks/check_MatchCommandRegex.py
@@ -56,6 +56,13 @@ def get_parser():
         action="store_true",
     )
 
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
+
     # }}}
     return parser
 
@@ -81,4 +88,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     regex = check_parsed_arguments.regex
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
-    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact)]
+    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact, reach)]

--- a/gator/checks/check_MatchCommandRegex.py
+++ b/gator/checks/check_MatchCommandRegex.py
@@ -88,4 +88,5 @@ def act(main_parsed_arguments, check_remaining_arguments):
     regex = check_parsed_arguments.regex
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [invoke.invoke_all_command_regex_checks(command, regex, count, exact, reach)]

--- a/gator/checks/check_MatchCommandRegex.py
+++ b/gator/checks/check_MatchCommandRegex.py
@@ -89,4 +89,4 @@ def act(main_parsed_arguments, check_remaining_arguments):
     count = check_parsed_arguments.count
     exact = check_parsed_arguments.exact
     reach = check_parsed_arguments.reach
-    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact, reach)]
+    return [invoke.invoke_all_command_regex_checks(command, regex, count, exact)]

--- a/gator/checks/check_MatchFileFragment.py
+++ b/gator/checks/check_MatchFileFragment.py
@@ -106,6 +106,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_fragment_checks(
-            fragment, count, file, directory, constants.markers.Nothing, exact, reach
+            fragment, count, file, directory, constants.markers.Nothing, exact
         )
     ]

--- a/gator/checks/check_MatchFileFragment.py
+++ b/gator/checks/check_MatchFileFragment.py
@@ -67,6 +67,14 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    # REACH: allows for a students to have a reach goal in their lab/practical
+    # REQUIRED? No
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
 
     # }}}
     return parser
@@ -95,8 +103,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_fragment_checks(
-            fragment, count, file, directory, constants.markers.Nothing, exact
+            fragment, count, file, directory, constants.markers.Nothing, exact, reach
         )
     ]

--- a/gator/checks/check_MatchFileFragment.py
+++ b/gator/checks/check_MatchFileFragment.py
@@ -103,7 +103,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_fragment_checks(
             fragment, count, file, directory, constants.markers.Nothing, exact

--- a/gator/checks/check_MatchFileFragment.py
+++ b/gator/checks/check_MatchFileFragment.py
@@ -103,9 +103,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_fragment_checks(
-            fragment, count, file, directory, constants.markers.Nothing, exact
+            fragment, count, file, directory, constants.markers.Nothing, exact, reach
         )
     ]

--- a/gator/checks/check_MatchFileRegex.py
+++ b/gator/checks/check_MatchFileRegex.py
@@ -101,6 +101,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_regex_checks(
             regex, count, file, directory, constants.markers.Nothing, exact, reach

--- a/gator/checks/check_MatchFileRegex.py
+++ b/gator/checks/check_MatchFileRegex.py
@@ -101,9 +101,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    # reach = check_parsed_arguments.reach
+    reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_regex_checks(
-            regex, count, file, directory, constants.markers.Nothing, exact
+            regex, count, file, directory, constants.markers.Nothing, exact, reach
         )
     ]

--- a/gator/checks/check_MatchFileRegex.py
+++ b/gator/checks/check_MatchFileRegex.py
@@ -67,6 +67,13 @@ def get_parser():
         action="store_true",
     )
 
+    optional_group.add_argument(
+        "--reach",
+        help="creates a higher goal for students to potentially reach",
+        default=False,
+        action="store_true",
+    )
+
     # }}}
     return parser
 
@@ -96,6 +103,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     exact = check_parsed_arguments.exact
     return [
         invoke.invoke_all_regex_checks(
-            regex, count, file, directory, constants.markers.Nothing, exact
+            regex, count, file, directory, constants.markers.Nothing, exact, reach
         )
     ]

--- a/gator/checks/check_MatchFileRegex.py
+++ b/gator/checks/check_MatchFileRegex.py
@@ -104,6 +104,6 @@ def act(main_parsed_arguments, check_remaining_arguments):
     reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_regex_checks(
-            regex, count, file, directory, constants.markers.Nothing, exact, reach
+            regex, count, file, directory, constants.markers.Nothing, exact
         )
     ]

--- a/gator/checks/check_MatchFileRegex.py
+++ b/gator/checks/check_MatchFileRegex.py
@@ -101,9 +101,9 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_regex_checks(
-            regex, count, file, directory, constants.markers.Nothing, exact, reach
+            regex, count, file, directory, constants.markers.Nothing, exact
         )
     ]

--- a/gator/checks/check_MatchFileRegex.py
+++ b/gator/checks/check_MatchFileRegex.py
@@ -101,7 +101,7 @@ def act(main_parsed_arguments, check_remaining_arguments):
     file = check_parsed_arguments.file
     directory = check_parsed_arguments.directory
     exact = check_parsed_arguments.exact
-    reach = check_parsed_arguments.reach
+    # reach = check_parsed_arguments.reach
     return [
         invoke.invoke_all_regex_checks(
             regex, count, file, directory, constants.markers.Nothing, exact

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -93,6 +93,7 @@ markers = create_constants(
     Unknown_File="unknown",
     Xmark="✘",
     Yes="Yes",
+    Circle="●"
 )
 
 # define the metavars

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -93,7 +93,7 @@ markers = create_constants(
     Unknown_File="unknown",
     Xmark="✘",
     Yes="Yes",
-    Circle="●"
+    Circle="●",
 )
 
 # define the metavars

--- a/gator/entities.py
+++ b/gator/entities.py
@@ -7,7 +7,12 @@ from gator import util
 
 # pylint: disable=bad-continuation
 def entity_greater_than_count_total(
-    given_file, containing_directory, expected_count, checking_function, exact=False
+    given_file,
+    containing_directory,
+    expected_count,
+    checking_function,
+    exact=False,
+    reach=False,
 ):
     """Return a count and determination if entity count is greater than expected."""
     # call the count_entities function in this module
@@ -15,7 +20,7 @@ def entity_greater_than_count_total(
         given_file, containing_directory, checking_function
     )
     count_status_list = util.greater_than_equal_exacted(
-        expected_count, file_entity_count, exact
+        expected_count, file_entity_count, exact, reach
     )
     count_status = count_status_list[0]
     return count_status, file_entity_count, file_entity_count_dictionary
@@ -23,7 +28,12 @@ def entity_greater_than_count_total(
 
 # pylint: disable=bad-continuation
 def entity_greater_than_count(
-    given_file, containing_directory, expected_count, checking_function, exact=False
+    given_file,
+    containing_directory,
+    expected_count,
+    checking_function,
+    exact=False,
+    reach=False,
 ):
     """Return a count and determination if entity count is greater than expected."""
     # call the count_entities function in this module
@@ -31,7 +41,7 @@ def entity_greater_than_count(
         given_file, containing_directory, checking_function
     )
     final_check_result_list = util.greater_than_equal_exacted(
-        file_entity_count, expected_count, exact
+        file_entity_count, expected_count, exact, reach
     )
     final_check_result = final_check_result_list[0]
     return final_check_result, file_entity_count, file_entity_count_dictionary

--- a/gator/fragments.py
+++ b/gator/fragments.py
@@ -160,6 +160,7 @@ def specified_entity_greater_than_count(
     containing_directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
+    reach=False,
 ):
     """Determine if the entity count is greater than expected."""
     # count the fragments/regex in either a file in a directory or String contents
@@ -168,7 +169,7 @@ def specified_entity_greater_than_count(
     )
     # check the condition and also return file_entity_count
     condition_truth, value = util.greater_than_equal_exacted(
-        file_entity_count, expected_count, exact
+        file_entity_count, expected_count, exact, reach
     )
     # also return an empty dictionary since this function does not
     # need to count details about multiple entities
@@ -226,6 +227,7 @@ def specified_source_greater_than_count(
     containing_directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
+    reach=False,
 ):
     """Determine if the line count is greater than expected."""
     # count the fragments in either a file in a directory or str contents,
@@ -238,7 +240,9 @@ def specified_source_greater_than_count(
     # and the dictionary itself so as to support good diagnostics
     return (
         (
-            util.greater_than_equal_exacted(file_lines_count, expected_count, exact),
+            util.greater_than_equal_exacted(
+                file_lines_count, expected_count, exact, reach
+            ),
             file_lines_count,
         ),
         file_contents_count_dictionary,

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -227,7 +227,7 @@ def invoke_all_comment_checks(
     return met_or_exceeded_count
 
 
-def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=False):
+def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=False, reach=False):
     """Perform the paragraph check and return the results."""
     met_or_exceeded_count = 0
     (

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -706,7 +706,7 @@ def invoke_all_command_fragment_checks(
 
 # pylint: disable=bad-continuation
 def invoke_all_command_regex_checks(
-    command, expected_regex, expected_count, exact=False
+    command, expected_regex, expected_count, exact=False, reach=False
 ):
     """Perform the check for a regex existence in the output of a command."""
     # Since the command did not produce any output (i.e., its output is "" or
@@ -725,6 +725,7 @@ def invoke_all_command_regex_checks(
         constants.markers.Nothing,
         command_output,
         exact,
+        reach
     )
 
 

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -84,7 +84,13 @@ def invoke_file_in_directory_check(filecheck, directory, reach=False):
 
 # pylint: disable=bad-continuation
 def invoke_all_comment_checks(
-    filecheck, directory, expected_count, comment_type, language, exact=False, reach=False
+    filecheck,
+    directory,
+    expected_count,
+    comment_type,
+    language,
+    exact=False,
+    reach=False,
 ):
     """Perform the comment check and return the results."""
     met_or_exceeded_count = 0
@@ -227,7 +233,9 @@ def invoke_all_comment_checks(
     return met_or_exceeded_count
 
 
-def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=False, reach=False):
+def invoke_all_paragraph_checks(
+    filecheck, directory, expected_count, exact=False, reach=False
+):
     """Perform the paragraph check and return the results."""
     met_or_exceeded_count = 0
     (
@@ -283,7 +291,13 @@ def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=Fals
 
 
 def invoke_all_minimum_word_count_checks(
-    filecheck, directory, expected_count, count_function, conclusion, exact=False, reach=False
+    filecheck,
+    directory,
+    expected_count,
+    count_function,
+    conclusion,
+    exact=False,
+    reach=False,
 ):
     """Perform the word count check and return the results."""
     met_or_exceeded_count = 0
@@ -367,7 +381,13 @@ def invoke_all_minimum_word_count_checks(
 
 
 def invoke_all_total_word_count_checks(
-    filecheck, directory, expected_count, count_function, conclusion, exact=False, reach=False
+    filecheck,
+    directory,
+    expected_count,
+    count_function,
+    conclusion,
+    exact=False,
+    reach=False,
 ):
     """Perform the word count check and return the results."""
     met_or_exceeded_count = False
@@ -457,7 +477,7 @@ def invoke_all_fragment_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
-    reach=False
+    reach=False,
 ):
     """Perform the check for a fragment existence in file or contents and return the results."""
     met_or_exceeded_count = 0
@@ -557,7 +577,7 @@ def invoke_all_regex_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
-    reach=False
+    reach=False,
 ):
     """Perform the check for a regex existence in file or contents and return the results."""
     met_or_exceeded_count = 0
@@ -674,7 +694,7 @@ def invoke_all_command_fragment_checks(
         constants.markers.Nothing,
         command_output,
         exact,
-        reach
+        reach,
     )
 
 
@@ -699,7 +719,7 @@ def invoke_all_command_regex_checks(
         constants.markers.Nothing,
         command_output,
         exact,
-        reach
+        reach,
     )
 
 
@@ -796,7 +816,7 @@ def invoke_all_count_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
-    reach=False
+    reach=False,
 ):
     """Perform the check for the count of lines in file or contents and return the results."""
     print("This is a reach variable")
@@ -878,5 +898,5 @@ def invoke_all_command_count_checks(command, expected_count, exact=False, reach=
         constants.markers.Nothing,
         command_output,
         exact,
-        reach
+        reach,
     )

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -723,7 +723,7 @@ def invoke_all_command_executes_checks(command):
 
 # pylint: disable=bad-continuation
 def invoke_all_markdown_checks(
-    markdown_tag, expected_count, filecheck, directory, exact=False
+    markdown_tag, expected_count, filecheck, directory, exact=False, reach=False
 ):
     """Perform the check for a markdown tag existence in a file and return the results."""
     met_or_exceeded_count = 0

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -457,6 +457,7 @@ def invoke_all_fragment_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
+    reach=False
 ):
     """Perform the check for a fragment existence in file or contents and return the results."""
     met_or_exceeded_count = 0
@@ -672,6 +673,7 @@ def invoke_all_command_fragment_checks(
         constants.markers.Nothing,
         command_output,
         exact,
+        reach
     )
 
 

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -22,7 +22,7 @@ def report_result(status, message, diagnostic):
         report.set_result(message, status, diagnostic)
 
 
-def invoke_commits_check(student_repository, expected_count, exact=False):
+def invoke_commits_check(student_repository, expected_count, exact=False, reach=False):
     """Check to see if the repository has more than specified commits."""
     # inspect the Git repository internals for the commits
     did_check_pass, actual_count = repository.commits_greater_than_count(

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -829,7 +829,7 @@ def invoke_all_count_checks(
         (met_or_exceeded_count, actual_count,),
         actual_count_dictionary,
     ) = fragments.specified_source_greater_than_count(
-        expected_count, filecheck, directory, contents, exact
+        expected_count, filecheck, directory, contents, exact, reach
     )
     # create a message for a file in directory
     if (

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -699,7 +699,7 @@ def invoke_all_command_regex_checks(
     )
 
 
-def invoke_all_command_executes_checks(command):
+def invoke_all_command_executes_checks(command, reach=False):
     """Perform the check for whether or not a command runs without error."""
     # pylint: disable=unused-variable
     # note that the program does not use all of these

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -792,8 +792,11 @@ def invoke_all_count_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
+    reach=False
 ):
     """Perform the check for the count of lines in file or contents and return the results."""
+    print("This is a reach variable")
+    print(reach)
     met_or_exceeded_count = 0
     (
         (met_or_exceeded_count, actual_count,),
@@ -862,7 +865,7 @@ def invoke_all_count_checks(
     return extracted_result
 
 
-def invoke_all_command_count_checks(command, expected_count, exact=False):
+def invoke_all_command_count_checks(command, expected_count, exact=False, reach=False):
     """Perform the check for number of lines in the output of a command."""
     command_output = run.specified_command_get_output(command)
     return invoke_all_count_checks(
@@ -871,4 +874,5 @@ def invoke_all_command_count_checks(command, expected_count, exact=False):
         constants.markers.Nothing,
         command_output,
         exact,
+        reach
     )

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -598,7 +598,7 @@ def invoke_all_regex_checks(
         directory,
         contents,
         exact,
-        reach
+        reach,
     )
     # create a message for a file in directory
     if (
@@ -725,7 +725,7 @@ def invoke_all_command_regex_checks(
         constants.markers.Nothing,
         command_output,
         exact,
-        reach
+        reach,
     )
 
 

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -557,6 +557,7 @@ def invoke_all_regex_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
+    reach=False
 ):
     """Perform the check for a regex existence in file or contents and return the results."""
     met_or_exceeded_count = 0
@@ -698,6 +699,7 @@ def invoke_all_command_regex_checks(
         constants.markers.Nothing,
         command_output,
         exact,
+        reach
     )
 
 

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -824,8 +824,6 @@ def invoke_all_count_checks(
     reach=False,
 ):
     """Perform the check for the count of lines in file or contents and return the results."""
-    print("This is a reach variable")
-    print(reach)
     met_or_exceeded_count = 0
     (
         (met_or_exceeded_count, actual_count,),

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -677,7 +677,7 @@ def invoke_all_command_fragment_checks(
 
 # pylint: disable=bad-continuation
 def invoke_all_command_regex_checks(
-    command, expected_regex, expected_count, exact=False
+    command, expected_regex, expected_count, exact=False, reach=False
 ):
     """Perform the check for a regex existence in the output of a command."""
     # Since the command did not produce any output (i.e., its output is "" or

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -26,7 +26,7 @@ def invoke_commits_check(student_repository, expected_count, exact=False, reach=
     """Check to see if the repository has more than specified commits."""
     # inspect the Git repository internals for the commits
     did_check_pass, actual_count = repository.commits_greater_than_count(
-        student_repository, expected_count, exact
+        student_repository, expected_count, exact, reach
     )
     # create the message and the diagnostic
     if not exact:
@@ -43,7 +43,7 @@ def invoke_commits_check(student_repository, expected_count, exact=False, reach=
     return did_check_pass
 
 
-def invoke_file_in_directory_check(filecheck, directory, reach=False):
+def invoke_file_in_directory_check(filecheck, directory):
     """Check to see if the file is in the directory."""
     # get the project home, which contains the content subject to checking
     gatorgrader_home = util.get_project_home()
@@ -110,6 +110,7 @@ def invoke_all_comment_checks(
                 expected_count,
                 comments.count_singleline_java_comment,
                 exact,
+                reach,
             )
         # check comments in Python
         if language == constants.languages.Python:
@@ -123,6 +124,7 @@ def invoke_all_comment_checks(
                 expected_count,
                 comments.count_singleline_python_comment,
                 exact,
+                reach,
             )
     # check multiple-line comments
     elif comment_type == constants.comments.Multiple_Line:
@@ -138,6 +140,7 @@ def invoke_all_comment_checks(
                 expected_count,
                 comments.count_multiline_java_comment,
                 exact,
+                reach,
             )
         # check comments in Python
         if language == constants.languages.Python:
@@ -151,6 +154,7 @@ def invoke_all_comment_checks(
                 expected_count,
                 comments.count_multiline_python_comment,
                 exact,
+                reach,
             )
     # check comments in a not-supported language
     # currently the only valid options are:
@@ -243,7 +247,7 @@ def invoke_all_paragraph_checks(
         actual_count,
         actual_count_dictionary,
     ) = entities.entity_greater_than_count(
-        filecheck, directory, expected_count, fragments.count_paragraphs, exact
+        filecheck, directory, expected_count, fragments.count_paragraphs, exact, reach
     )
     # create the message and the diagnostic
     if not exact:
@@ -306,7 +310,7 @@ def invoke_all_minimum_word_count_checks(
         actual_count,
         actual_count_dictionary,
     ) = entities.entity_greater_than_count(
-        filecheck, directory, expected_count, count_function, exact
+        filecheck, directory, expected_count, count_function, exact, reach
     )
     # create the message and the diagnostic
     if not exact:
@@ -396,10 +400,10 @@ def invoke_all_total_word_count_checks(
         actual_count,
         actual_count_dictionary,
     ) = entities.entity_greater_than_count_total(
-        filecheck, directory, expected_count, count_function, exact
+        filecheck, directory, expected_count, count_function, exact, reach
     )
     met_or_exceeded_count = util.greater_than_equal_exacted(
-        actual_count, expected_count, exact
+        actual_count, expected_count, exact, reach
     )[0]
     # create the message and the diagnostic
     if not exact:
@@ -493,6 +497,7 @@ def invoke_all_fragment_checks(
         directory,
         contents,
         exact,
+        reach,
     )
     # create a message for a file in directory
     if (
@@ -577,7 +582,7 @@ def invoke_all_regex_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
-    reach=False,
+    # reach=False,
 ):
     """Perform the check for a regex existence in file or contents and return the results."""
     met_or_exceeded_count = 0
@@ -700,7 +705,7 @@ def invoke_all_command_fragment_checks(
 
 # pylint: disable=bad-continuation
 def invoke_all_command_regex_checks(
-    command, expected_regex, expected_count, exact=False, reach=False
+    command, expected_regex, expected_count, exact=False
 ):
     """Perform the check for a regex existence in the output of a command."""
     # Since the command did not produce any output (i.e., its output is "" or
@@ -719,11 +724,10 @@ def invoke_all_command_regex_checks(
         constants.markers.Nothing,
         command_output,
         exact,
-        reach,
     )
 
 
-def invoke_all_command_executes_checks(command, reach=False):
+def invoke_all_command_executes_checks(command):
     """Perform the check for whether or not a command runs without error."""
     # pylint: disable=unused-variable
     # note that the program does not use all of these
@@ -763,6 +767,7 @@ def invoke_all_markdown_checks(
         filecheck,
         directory,
         exact,
+        reach,
     )
     # create an "at least" message which is the default
     if exact is not True:

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -84,7 +84,7 @@ def invoke_file_in_directory_check(filecheck, directory):
 
 # pylint: disable=bad-continuation
 def invoke_all_comment_checks(
-    filecheck, directory, expected_count, comment_type, language, exact=False
+    filecheck, directory, expected_count, comment_type, language, exact=False, reach=False
 ):
     """Perform the comment check and return the results."""
     met_or_exceeded_count = 0

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -582,7 +582,7 @@ def invoke_all_regex_checks(
     directory=constants.markers.Nothing,
     contents=constants.markers.Nothing,
     exact=False,
-    # reach=False,
+    reach=False,
 ):
     """Perform the check for a regex existence in file or contents and return the results."""
     met_or_exceeded_count = 0
@@ -598,6 +598,7 @@ def invoke_all_regex_checks(
         directory,
         contents,
         exact,
+        reach
     )
     # create a message for a file in directory
     if (

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -43,7 +43,7 @@ def invoke_commits_check(student_repository, expected_count, exact=False):
     return did_check_pass
 
 
-def invoke_file_in_directory_check(filecheck, directory, reach):
+def invoke_file_in_directory_check(filecheck, directory):
     """Check to see if the file is in the directory."""
     # get the project home, which contains the content subject to checking
     gatorgrader_home = util.get_project_home()
@@ -51,6 +51,7 @@ def invoke_file_in_directory_check(filecheck, directory, reach):
     directory_path = files.create_path(home=directory)
     # the directory is absolute, meaning that it does not need to be
     # rooted in the context of the project directory
+    # reach = " "
     if directory_path.is_absolute():
         was_file_found = files.check_file_in_directory(file=filecheck, home=directory)
     # the directory is not absolute, meaning that it should be rooted

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -653,7 +653,7 @@ def invoke_all_regex_checks(
 
 # pylint: disable=bad-continuation
 def invoke_all_command_fragment_checks(
-    command, expected_fragment, expected_count, exact=False
+    command, expected_fragment, expected_count, exact=False, reach=False
 ):
     """Perform the check for a fragment existence in the output of a command."""
     command_output = run.specified_command_get_output(command)

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -43,7 +43,7 @@ def invoke_commits_check(student_repository, expected_count, exact=False):
     return did_check_pass
 
 
-def invoke_file_in_directory_check(filecheck, directory):
+def invoke_file_in_directory_check(filecheck, directory, reach):
     """Check to see if the file is in the directory."""
     # get the project home, which contains the content subject to checking
     gatorgrader_home = util.get_project_home()

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -283,7 +283,7 @@ def invoke_all_paragraph_checks(filecheck, directory, expected_count, exact=Fals
 
 
 def invoke_all_minimum_word_count_checks(
-    filecheck, directory, expected_count, count_function, conclusion, exact=False
+    filecheck, directory, expected_count, count_function, conclusion, exact=False, reach=False
 ):
     """Perform the word count check and return the results."""
     met_or_exceeded_count = 0

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -43,7 +43,7 @@ def invoke_commits_check(student_repository, expected_count, exact=False, reach=
     return did_check_pass
 
 
-def invoke_file_in_directory_check(filecheck, directory):
+def invoke_file_in_directory_check(filecheck, directory, reach=False):
     """Check to see if the file is in the directory."""
     # get the project home, which contains the content subject to checking
     gatorgrader_home = util.get_project_home()

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -367,7 +367,7 @@ def invoke_all_minimum_word_count_checks(
 
 
 def invoke_all_total_word_count_checks(
-    filecheck, directory, expected_count, count_function, conclusion, exact=False
+    filecheck, directory, expected_count, count_function, conclusion, exact=False, reach=False
 ):
     """Perform the word count check and return the results."""
     met_or_exceeded_count = False

--- a/gator/markdown.py
+++ b/gator/markdown.py
@@ -26,6 +26,7 @@ def specified_tag_greater_than_count(
     given_file,
     containing_directory,
     exact=False,
+    reach=False,
 ):
     """Determine if the tag count is greater than expected in given file(s)."""
     # Use these two variables to keep track of tag counts for multiple files.
@@ -50,6 +51,6 @@ def specified_tag_greater_than_count(
     file_tags_count = minimum_pair[1]
     # check the condition and also return file_tags_count
     return (
-        util.greater_than_equal_exacted(file_tags_count, expected_count, exact),
+        util.greater_than_equal_exacted(file_tags_count, expected_count, exact, reach),
         file_tags_count_dictionary,
     )

--- a/gator/repository.py
+++ b/gator/repository.py
@@ -48,10 +48,10 @@ def count_commits(commits):
     return len(commits)
 
 
-def commits_greater_than_count(path, expected_count, exact=False):
+def commits_greater_than_count(path, expected_count, exact=False, reach=False):
     """Return count and True if count of commits is greater than limit, else False."""
     # extract the commit log and then count the commits
     commits = get_commits(path)
     number_commits = count_commits(commits)
     # check the condition and also return number_commits
-    return util.greater_than_equal_exacted(number_commits, expected_count, exact)
+    return util.greater_than_equal_exacted(number_commits, expected_count, exact, reach)

--- a/gator/util.py
+++ b/gator/util.py
@@ -189,13 +189,15 @@ def is_json(potential_json):
     return True
 
 
-def greater_than_equal_exacted(first, second, exact=False):
+def greater_than_equal_exacted(first, second, exact=False, reach=False):
     """Return True if first >= second unless exact, then True if ==, otherwise False."""
     if not exact and first >= second:
         return True, first
     if exact and first == second:
         return True, first
     return False, first
+    if reach:
+        print("hello")
 
 
 def get_number_as_words(number, format=constants.words.Ordinal):

--- a/tests/checks/test_check_CountCommandOutput.py
+++ b/tests/checks/test_check_CountCommandOutput.py
@@ -149,7 +149,7 @@ def test_optional_commandline_arguments_can_parse_created_parser(
                 "--count",
                 "0",
                 "--exact",
-                "--reach"
+                "--reach",
             ],
             True,
         ),

--- a/tests/checks/test_check_CountCommandOutput.py
+++ b/tests/checks/test_check_CountCommandOutput.py
@@ -140,6 +140,19 @@ def test_optional_commandline_arguments_can_parse_created_parser(
             ],
             False,
         ),
+        (["CountCommandOutput", "--command", "WrongCommand", "--count", "0"], True),
+        (
+            [
+                "CountCommandOutput",
+                "--command",
+                "WrongCommand",
+                "--count",
+                "0",
+                "--exact",
+                "--reach"
+            ],
+            True,
+        ),
     ],
 )
 def test_act_produces_output(commandline_arguments, expected_result, load_checker):

--- a/tests/checks/test_check_CountCommandOutput.py
+++ b/tests/checks/test_check_CountCommandOutput.py
@@ -22,7 +22,7 @@ def test_no_arguments_incorrect_system_exit(capsys):
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 3
+    assert counted_newlines == 2
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,7 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 3
+    assert counted_newlines == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/checks/test_check_CountCommandOutput.py
+++ b/tests/checks/test_check_CountCommandOutput.py
@@ -56,6 +56,7 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
         (["--count", "5", "--command", "run_command_second"]),
         (["--command", "run_command_first", "--count", "5"]),
         (["--command", "run_command_first", "--count", "5", "--exact"]),
+        (["--command", "run_command_first", "--count", "5", "--exact", "--reach"]),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -71,6 +72,7 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
         (["--count", "5", "--command", "run_command_second"]),
         (["--command", "run_command_first", "--count", "5"]),
         (["--command", "run_command_first", "--count", "5", "--exact"]),
+        (["--command", "run_command_first", "--count", "5", "--exact", "--reach"]),
     ],
 )
 def test_optional_commandline_arguments_can_parse_created_parser(

--- a/tests/checks/test_check_CountCommandOutput.py
+++ b/tests/checks/test_check_CountCommandOutput.py
@@ -22,7 +22,7 @@ def test_no_arguments_incorrect_system_exit(capsys):
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 2
+    assert counted_newlines == 3
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,7 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 2
+    assert counted_newlines == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/checks/test_check_CountCommits.py
+++ b/tests/checks/test_check_CountCommits.py
@@ -49,7 +49,7 @@ def test_optional_commandline_arguments_cannot_verify(commandline_arguments, cap
 
 
 @pytest.mark.parametrize(
-    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"]),],
+    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"])]
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
     """Check that correct optional command-line arguments check correctly."""
@@ -58,7 +58,7 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
 
 
 @pytest.mark.parametrize(
-    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"]),],
+    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"])]
 )
 def test_optional_commandline_arguments_can_parse_created_parser(
     commandline_arguments, not_raises

--- a/tests/checks/test_check_CountCommits.py
+++ b/tests/checks/test_check_CountCommits.py
@@ -27,7 +27,12 @@ def test_no_arguments_incorrect_system_exit(capsys):
 
 @pytest.mark.parametrize(
     "commandline_arguments",
-    [(["--countWRONG", "5"]), (["--count", "5", "--exactWRONG"]), (["--exact"])],
+    [
+        (["--countWRONG", "5"]),
+        (["--count", "5", "--exactWRONG"]),
+        (["--exact"]),
+        (["--reach"]),
+    ],
 )
 def test_optional_commandline_arguments_cannot_verify(commandline_arguments, capsys):
     """Check that incorrect optional command-line arguments check correctly."""
@@ -44,7 +49,11 @@ def test_optional_commandline_arguments_cannot_verify(commandline_arguments, cap
 
 
 @pytest.mark.parametrize(
-    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"])]
+    "commandline_arguments",
+    [
+        (["--count", "5"]),
+        (["--count", "5", "--exact"]),
+    ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
     """Check that correct optional command-line arguments check correctly."""
@@ -53,7 +62,11 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
 
 
 @pytest.mark.parametrize(
-    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"])]
+    "commandline_arguments",
+    [
+        (["--count", "5"]),
+        (["--count", "5", "--exact"]),
+    ],
 )
 def test_optional_commandline_arguments_can_parse_created_parser(
     commandline_arguments, not_raises
@@ -70,6 +83,7 @@ def test_optional_commandline_arguments_can_parse_created_parser(
         (["CountCommits", "--count", "0"], True),
         (["CountCommits", "--count", "5"], True),
         (["CountCommits", "--count", "5", "--exact"], False),
+        (["CountCommits", "--count", "5", "--exact", "--reach"], False),
     ],
 )
 def test_act_produces_output(commandline_arguments, expected_result, load_checker):

--- a/tests/checks/test_check_CountCommits.py
+++ b/tests/checks/test_check_CountCommits.py
@@ -49,11 +49,7 @@ def test_optional_commandline_arguments_cannot_verify(commandline_arguments, cap
 
 
 @pytest.mark.parametrize(
-    "commandline_arguments",
-    [
-        (["--count", "5"]),
-        (["--count", "5", "--exact"]),
-    ],
+    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"]),],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
     """Check that correct optional command-line arguments check correctly."""
@@ -62,11 +58,7 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
 
 
 @pytest.mark.parametrize(
-    "commandline_arguments",
-    [
-        (["--count", "5"]),
-        (["--count", "5", "--exact"]),
-    ],
+    "commandline_arguments", [(["--count", "5"]), (["--count", "5", "--exact"]),],
 )
 def test_optional_commandline_arguments_can_parse_created_parser(
     commandline_arguments, not_raises

--- a/tests/checks/test_check_CountFileLines.py
+++ b/tests/checks/test_check_CountFileLines.py
@@ -23,7 +23,7 @@ def test_no_arguments_incorrect_system_exit(capsys):
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 2
+    assert counted_newlines == 3
 
 
 @pytest.mark.parametrize(
@@ -49,7 +49,7 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 2
+    assert counted_newlines == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/checks/test_check_CountFileLines.py
+++ b/tests/checks/test_check_CountFileLines.py
@@ -36,6 +36,17 @@ def test_no_arguments_incorrect_system_exit(capsys):
         (["--file", "filename", "--directoryWRONG", "directory"]),
         (["--file", "filename", "--directory", "directory", "--count"]),
         (["--file", "filename", "--directory", "directory", "--countWRONG", "5"]),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--countWRONG",
+                "5",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_cannot_parse(commandline_arguments, capsys):
@@ -201,6 +212,7 @@ def test_act_produces_output(
             overall_directory,
             "--count",
             provided_count,
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/checks/test_check_CountFileLines.py
+++ b/tests/checks/test_check_CountFileLines.py
@@ -59,6 +59,17 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -74,6 +85,17 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_optional_commandline_arguments_can_parse_created_parser(

--- a/tests/checks/test_check_CountFileParagraphs.py
+++ b/tests/checks/test_check_CountFileParagraphs.py
@@ -72,6 +72,17 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -203,6 +214,7 @@ def test_act_produces_output(
             overall_directory,
             "--count",
             provided_count,
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/checks/test_check_CountFileParagraphs.py
+++ b/tests/checks/test_check_CountFileParagraphs.py
@@ -38,6 +38,17 @@ def test_no_arguments_incorrect_system_exit(capsys):
         (["--file", "filename", "--directoryWRONG", "directory"]),
         (["--file", "filename", "--directory", "directory", "--count"]),
         (["--file", "filename", "--directory", "directory", "--countWRONG", "5"]),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--countWRONG",
+                "5",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_cannot_parse(commandline_arguments, capsys):
@@ -76,6 +87,17 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_optional_commandline_arguments_can_parse_created_parser(

--- a/tests/checks/test_check_CountFileWords.py
+++ b/tests/checks/test_check_CountFileWords.py
@@ -23,7 +23,7 @@ def test_no_arguments_incorrect_system_exit(capsys):
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 2
+    assert counted_newlines == 3
 
 
 @pytest.mark.parametrize(
@@ -49,7 +49,7 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 2
+    assert counted_newlines == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/checks/test_check_CountFileWords.py
+++ b/tests/checks/test_check_CountFileWords.py
@@ -70,6 +70,17 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -85,6 +96,17 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_optional_commandline_arguments_can_parse_created_parser(
@@ -195,6 +217,7 @@ def test_act_produces_output(
             overall_directory,
             "--count",
             provided_count,
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/checks/test_check_CountFileWords.py
+++ b/tests/checks/test_check_CountFileWords.py
@@ -36,6 +36,17 @@ def test_no_arguments_incorrect_system_exit(capsys):
         (["--file", "filename", "--directoryWRONG", "directory"]),
         (["--file", "filename", "--directory", "directory", "--count"]),
         (["--file", "filename", "--directory", "directory", "--countWRONG", "5"]),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--countWRONG",
+                "5",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_cannot_parse(commandline_arguments, capsys):

--- a/tests/checks/test_check_CountMarkdownTags.py
+++ b/tests/checks/test_check_CountMarkdownTags.py
@@ -140,6 +140,19 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
                 "--reach",
             ]
         ),
+        (
+            [
+                "--tag",
+                "code",
+                "--count",
+                "5",
+                "--directory",
+                "directoryname",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -197,6 +210,19 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
                 "5",
                 "--file",
                 "filename",
+            ]
+        ),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--tag",
+                "code",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
             ]
         ),
     ],
@@ -336,6 +362,7 @@ of GatorGrader. Depending on your goals, there are several different..."""
             provided_count,
             "--tag",
             "heading",
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)
@@ -485,6 +512,7 @@ of GatorGrader. Depending on your goals, there are several different..."""
             "--tag",
             "heading",
             "--exact",
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/checks/test_check_CountMarkdownTags.py
+++ b/tests/checks/test_check_CountMarkdownTags.py
@@ -44,6 +44,17 @@ def test_no_arguments_incorrect_system_exit(capsys):
                 "--directory",
                 "directory",
                 "--count",
+                "--tag",
+                "--reach",
+            ]
+        ),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--count",
                 "5",
                 "--tagWRONG",
                 "code",
@@ -114,6 +125,19 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
                 "5",
                 "--file",
                 "filename",
+            ]
+        ),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--tag",
+                "code",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
             ]
         ),
     ],

--- a/tests/checks/test_check_CountParagraphWords.py
+++ b/tests/checks/test_check_CountParagraphWords.py
@@ -36,6 +36,17 @@ def test_no_arguments_incorrect_system_exit(capsys):
         (["--file", "filename", "--directoryWRONG", "directory"]),
         (["--file", "filename", "--directory", "directory", "--count"]),
         (["--file", "filename", "--directory", "directory", "--countWRONG", "5"]),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--countWRONG",
+                "5",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_cannot_parse(commandline_arguments, capsys):
@@ -59,6 +70,17 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -74,6 +96,17 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
         (["--directory", "directoryname", "--file", "filename", "--count", "5"]),
         (["--count", "5", "--directory", "directoryname", "--file", "filename"]),
         (["--directory", "directoryname", "--count", "5", "--file", "filename"]),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_optional_commandline_arguments_can_parse_created_parser(
@@ -184,6 +217,7 @@ def test_act_produces_output(
             overall_directory,
             "--count",
             provided_count,
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/checks/test_check_CountSingleLineComments.py
+++ b/tests/checks/test_check_CountSingleLineComments.py
@@ -95,6 +95,30 @@ def test_no_arguments_incorrect_system_exit(capsys):
                 "Python",
             ]
         ),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--countWRONG",
+                "5",
+                "--reach",
+            ]
+        ),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--count",
+                "5",
+                "--languageWRONG",
+                "Python",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_cannot_parse(commandline_arguments, capsys):
@@ -186,6 +210,19 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
                 "Java",
             ]
         ),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--language",
+                "Java",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -267,6 +304,19 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
                 "filename",
                 "--language",
                 "Java",
+            ]
+        ),
+        (
+            [
+                "--count",
+                "5",
+                "--directory",
+                "directoryname",
+                "--file",
+                "filename",
+                "--language",
+                "Python",
+                "--reach",
             ]
         ),
     ],
@@ -384,6 +434,7 @@ def test_act_produces_output_python(
             provided_count,
             "--language",
             "Python",
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)
@@ -506,6 +557,7 @@ def test_act_produces_output_java(
             provided_count,
             "--language",
             "Java",
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/checks/test_check_MatchCommandFragment.py
+++ b/tests/checks/test_check_MatchCommandFragment.py
@@ -33,6 +33,8 @@ def test_no_arguments_incorrect_system_exit(capsys):
         (["--count", "5", "--fragmentWRONG", "hi", "--exact"]),
         (["--count", "5", "--exactWRONG"]),
         (["--exact"]),
+        (["--count", "5", "--fragmentWRONG", "hi", "--exact", "--reach"]),
+        (["--reach"]),
     ],
 )
 def test_optional_commandline_arguments_cannot_verify(commandline_arguments, capsys):
@@ -62,6 +64,17 @@ def test_optional_commandline_arguments_cannot_verify(commandline_arguments, cap
                 "fragment",
                 "--count",
                 "5",
+                "--reach",
+            ]
+        ),
+        (
+            [
+                "--command",
+                "run_command_first",
+                "--fragment",
+                "fragment",
+                "--count",
+                "5",
                 "--exact",
             ]
         ),
@@ -74,6 +87,18 @@ def test_optional_commandline_arguments_cannot_verify(commandline_arguments, cap
                 "--count",
                 "5",
                 "--exact",
+            ]
+        ),
+        (
+            [
+                "--command",
+                "run_command_second",
+                "--fragment",
+                "fragment",
+                "--count",
+                "5",
+                "--exact",
+                "--reach",
             ]
         ),
     ],
@@ -100,6 +125,17 @@ def test_optional_commandline_arguments_can_parse_created_parser(
                 "fragment",
                 "--count",
                 "5",
+                "--reach",
+            ]
+        ),
+        (
+            [
+                "--command",
+                "run_command_first",
+                "--fragment",
+                "fragment",
+                "--count",
+                "5",
                 "--exact",
             ]
         ),
@@ -112,6 +148,18 @@ def test_optional_commandline_arguments_can_parse_created_parser(
                 "--count",
                 "5",
                 "--exact",
+            ]
+        ),
+        (
+            [
+                "--command",
+                "run_command_second",
+                "--fragment",
+                "fragment",
+                "--count",
+                "5",
+                "--exact",
+                "--reach",
             ]
         ),
     ],

--- a/tests/checks/test_check_MatchFileFragment.py
+++ b/tests/checks/test_check_MatchFileFragment.py
@@ -49,6 +49,17 @@ def test_no_arguments_incorrect_system_exit(capsys):
                 "fragment",
             ]
         ),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--count",
+                "--fragment",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_cannot_parse(commandline_arguments, capsys):
@@ -116,6 +127,19 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
                 "filename",
             ]
         ),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--fragment",
+                "fragment",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -173,6 +197,19 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
                 "5",
                 "--file",
                 "filename",
+            ]
+        ),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directoryname",
+                "--count",
+                "5",
+                "--fragment",
+                "fragment",
+                "--reach",
             ]
         ),
     ],
@@ -290,6 +327,7 @@ def test_act_produces_output(
             provided_count,
             "--fragment",
             "hello",
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/checks/test_check_MatchFileRegex.py
+++ b/tests/checks/test_check_MatchFileRegex.py
@@ -49,6 +49,17 @@ def test_no_arguments_incorrect_system_exit(capsys):
                 "(regex)+",
             ]
         ),
+        (
+            [
+                "--file",
+                "filename",
+                "--directory",
+                "directory",
+                "--count",
+                "--regex",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_cannot_parse(commandline_arguments, capsys):
@@ -116,6 +127,19 @@ def test_required_commandline_arguments_cannot_parse(commandline_arguments, caps
                 "filename",
             ]
         ),
+        (
+            [
+                "--directory",
+                "directoryname",
+                "--regex",
+                "(regex)+",
+                "--count",
+                "5",
+                "--file",
+                "filename",
+                "--reach",
+            ]
+        ),
     ],
 )
 def test_required_commandline_arguments_can_parse(commandline_arguments, not_raises):
@@ -173,6 +197,19 @@ def test_required_commandline_arguments_can_parse(commandline_arguments, not_rai
                 "5",
                 "--file",
                 "filename",
+            ]
+        ),
+        (
+            [
+                "--regex",
+                "(regex)+",
+                "--count",
+                "5",
+                "--directory",
+                "directoryname",
+                "--file",
+                "filename",
+                "--reach",
             ]
         ),
     ],
@@ -290,6 +327,7 @@ def test_act_produces_output(
             provided_count,
             "--regex",
             "(hel)*",
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)
@@ -385,6 +423,7 @@ of GatorGrader. Depending on your goals, there are several different..."""
             provided_count,
             "--regex",
             "[##] [\\w\\s]* GatorGrader[?]?[\\n]",
+            "--reach",
         ]
         parsed_arguments, remaining_arguments = arguments.parse(commandline_arguments)
         args_verified = arguments.verify(parsed_arguments)

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -559,6 +559,7 @@ def test_comment_counts_check_single_java(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
+    # reach = "5 more commits"
     invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -46,8 +46,7 @@ def test_file_exists_in_directory_check(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "sub"
     hello_file = "hello.txt"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     # file is found in the specified directory
     assert details is not None
@@ -64,8 +63,7 @@ def test_file_exists_in_directory_check_test_file(reset_results_dictionary):
     with patch.object(sys, "argv", testargs):
         directory = "tests"
         test_file = "test_invoke.py"
-        reach = "5 more commits"
-        invoke.invoke_file_in_directory_check(test_file, directory, reach)
+        invoke.invoke_file_in_directory_check(test_file, directory)
         details = report.get_result()
         # file is found in the specified directory
         assert details is not None
@@ -561,8 +559,7 @@ def test_comment_counts_check_single_java(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -581,8 +578,7 @@ def test_comment_counts_check_single_java_exact(reset_results_dictionary, tmpdir
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -603,8 +599,7 @@ def test_comment_counts_check_single_python(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.py"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -623,8 +618,7 @@ def test_comment_counts_check_multiple_java(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -645,8 +639,7 @@ def test_comment_counts_check_multiple_java_invalid_check(
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -670,8 +663,7 @@ def test_comment_counts_check_multiple_java_not_enough(
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -693,8 +685,7 @@ def test_comment_counts_check_multiple_python(reset_results_dictionary, tmpdir):
     # directory = tmpdir.dirname + '"""' + tmpdir.basename + '"""' + "subdirectory"
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.py"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -719,8 +710,7 @@ def test_comment_counts_check_multiple_python_not_enough(
     # directory = tmpdir.dirname + '"""' + tmpdir.basename + '"""' + "subdirectory"
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.py"
-    reach = "5 more commits"
-    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
+    invoke.invoke_file_in_directory_check(hello_file, directory)
     details = report.get_result()
     assert details is not None
     report.reset()

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -46,7 +46,8 @@ def test_file_exists_in_directory_check(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "sub"
     hello_file = "hello.txt"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     # file is found in the specified directory
     assert details is not None
@@ -63,7 +64,8 @@ def test_file_exists_in_directory_check_test_file(reset_results_dictionary):
     with patch.object(sys, "argv", testargs):
         directory = "tests"
         test_file = "test_invoke.py"
-        invoke.invoke_file_in_directory_check(test_file, directory)
+        reach = "5 more commits"
+        invoke.invoke_file_in_directory_check(test_file, directory, reach)
         details = report.get_result()
         # file is found in the specified directory
         assert details is not None
@@ -559,7 +561,8 @@ def test_comment_counts_check_single_java(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -578,7 +581,8 @@ def test_comment_counts_check_single_java_exact(reset_results_dictionary, tmpdir
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -599,7 +603,8 @@ def test_comment_counts_check_single_python(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.py"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -618,7 +623,8 @@ def test_comment_counts_check_multiple_java(reset_results_dictionary, tmpdir):
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -639,7 +645,8 @@ def test_comment_counts_check_multiple_java_invalid_check(
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -663,7 +670,8 @@ def test_comment_counts_check_multiple_java_not_enough(
     assert len(tmpdir.listdir()) == 1
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.java"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -685,7 +693,8 @@ def test_comment_counts_check_multiple_python(reset_results_dictionary, tmpdir):
     # directory = tmpdir.dirname + '"""' + tmpdir.basename + '"""' + "subdirectory"
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.py"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()
@@ -710,7 +719,8 @@ def test_comment_counts_check_multiple_python_not_enough(
     # directory = tmpdir.dirname + '"""' + tmpdir.basename + '"""' + "subdirectory"
     directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "subdirectory"
     hello_file = "Hello.py"
-    invoke.invoke_file_in_directory_check(hello_file, directory)
+    reach = "5 more commits"
+    invoke.invoke_file_in_directory_check(hello_file, directory, reach)
     details = report.get_result()
     assert details is not None
     report.reset()


### PR DESCRIPTION
This PR is a feature that adds the `--reach` argument to all of the checks. This PR must work in conjunction with the [Feature/reach goal PR](https://github.com/GatorEducator/gatorgradle/pull/70) for the GatorGradle plugin.

We thought it was an important feature to add because we have noticed that some students need a reach goal in mind to push them or challenge them a little more in the classroom. We are still unsure of how to connect this to the correct output if the user completes or does not complete this check. Further research and testing will assist with this. Consequently, there is still more work that needs to go in to this PR and topic. 

Fixes #205

Notes: @gkapfham added a description that follows the pr-tag-release standard. Also, @gkapfham removed the following phrases from the start of this PR's description:

```
This PR represents the addition of the optional argument `--reach` to some checks. The reason it is not all is because not all checks will have the capabilities of being a "reach" goal.
```

@corlettim and @schultzh if it is not possible to make this work for all of the checks, then can you please list the ones for which this will not work and explain why it won't work for each one? 