### PR TITLE
Add description argument to enable custom check descriptions

### DIFF
--- a/gator/arguments.py
+++ b/gator/arguments.py
@@ -71,6 +71,15 @@ def parse(args):
         action="store_true",
     )
 
+    # DESCRIPTION: the description to use for the ran check
+    # REQUIRED? No
+    # CORRECT WHEN: it is a string that does not contain double-quotes
+    parser.add_argument(
+        constants.commandlines.Description,
+        help=constants.help.Description,
+        type=str,
+    )
+
     # }}}
 
     # Required Positional Argument {{{
@@ -108,5 +117,12 @@ def verify(args):
         checkerdir_path = files.create_path(file="", home=args.checkerdir)
         # the directory does exist, so this argument is verified
         if checkerdir_path.is_dir():
+            verified_arguments = True
+    # DESCRIPTION: a string to use as the check result's message
+    if args.description is not None:
+        # assume that the description is not valid
+        verified_arguments = False
+        if '"' not in args.description:
+            # the description does not contain double-quotes, so this argument is verified
             verified_arguments = True
     return verified_arguments

--- a/gator/arguments.py
+++ b/gator/arguments.py
@@ -2,6 +2,7 @@
 
 from gator import checkers
 from gator import constants
+from gator import description
 from gator import display
 from gator import files
 
@@ -110,19 +111,16 @@ def verify(args):
     # assume the arguments are valid, then prove otherwise
     verified_arguments = True
     # CHECKERDIR: an external directory of checks was specified
-    # ENSURE: this directory is a valid directory
+    # ENSURE: the directory is a valid directory
     if args.checkerdir is not None:
-        # assume that it is not a valid directory, then prove otherwise
-        verified_arguments = False
+        # if the directory does exist, this argument is verified
         checkerdir_path = files.create_path(file="", home=args.checkerdir)
-        # the directory does exist, so this argument is verified
-        if checkerdir_path.is_dir():
-            verified_arguments = True
+        verified_arguments = verified_arguments and checkerdir_path.is_dir()
     # DESCRIPTION: a string to use as the check result's message
+    # ENSURE: the description is a valid description
     if args.description is not None:
         # assume that the description is not valid
-        verified_arguments = False
-        if '"' not in args.description:
-            # the description does not contain double-quotes, so this argument is verified
-            verified_arguments = True
+        verified_arguments = verified_arguments and description.is_valid_description(
+            args.description
+        )
     return verified_arguments

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -42,6 +42,7 @@ commandlines = create_constants(
     Json="--json",
     List_Checks="--listchecks",
     No_Welcome="--nowelcome",
+    Description="--description",
 )
 
 # define the types of comments
@@ -63,6 +64,7 @@ help = create_constants(
     Json="print the status report in JSON",
     List_Checks="list the internal and user-provided checks",
     No_Welcome="do not display the welcome message",
+    Description="string to use as description of check",
 )
 
 # define the programming languages for comment checks

--- a/gator/constants.py
+++ b/gator/constants.py
@@ -137,7 +137,7 @@ program = create_constants("program", Name="gatorgrader.py")
 # capitalized because the JSON report that is transmitted
 # between Python and Java expects that the keys are lowercase
 results = create_constants(
-    "results", Check="check", Outcome="outcome", Diagnostic="diagnostic"
+    "results", Description="check", Outcome="outcome", Diagnostic="diagnostic"
 )
 
 # define the version control repository details

--- a/gator/description.py
+++ b/gator/description.py
@@ -1,0 +1,16 @@
+"""Utility functions to aid handling user-defined check descriptions"""
+
+from gator import constants
+
+
+def get_description_argument(args):
+    """Extract the user-provided description from the provided command-line arguments."""
+    return args.description
+
+
+def transform_result_dictionary(args, result_dict):
+    """Transform the produced check_result from the provided command-line arguments, if possible."""
+    desc = get_description_argument(args)
+    if desc is not None:
+        result_dict[constants.results.Check] = desc
+    return result_dict

--- a/gator/description.py
+++ b/gator/description.py
@@ -1,4 +1,4 @@
-"""Utility functions to aid handling user-defined check descriptions"""
+"""Utility functions to aid handling user-defined check descriptions."""
 
 from gator import constants
 

--- a/gator/description.py
+++ b/gator/description.py
@@ -9,8 +9,8 @@ def get_description_argument(args):
 
 
 def transform_result_dictionary(args, result_dict):
-    """Transform the produced check_result from the provided command-line arguments, if possible."""
+    """Transform the produced result dictionary from the provided command-line arguments, if possible."""
     desc = get_description_argument(args)
     if desc is not None:
-        result_dict[constants.results.Check] = desc
+        result_dict[constants.results.Description] = desc
     return result_dict

--- a/gator/description.py
+++ b/gator/description.py
@@ -14,3 +14,10 @@ def transform_result_dictionary(args, result_dict):
     if desc is not None:
         result_dict[constants.results.Description] = desc
     return result_dict
+
+
+def is_valid_description(description):
+    """Check whether the provided description is valid."""
+    return (
+        isinstance(description, str) and len(description) > 0 and '"' not in description
+    )

--- a/gator/orchestrate.py
+++ b/gator/orchestrate.py
@@ -5,6 +5,7 @@ import sys
 from gator import arguments
 from gator import checkers
 from gator import constants
+from gator import description
 
 from gator import leave
 from gator import report
@@ -120,8 +121,13 @@ def check(system_arguments):
     check_result = check.act(parsed_arguments, remaining_arguments)
     check_results.extend(check_result)
     # *Section: Output the report
-    # Only step: get the report's details, produce the output, and display it
+    # **Step: get the report's details
+    result = report.get_result()
+    # **Step: Override the result's description if a user-provided description exists
+    result = description.transform_result_dictionary(parsed_arguments, result)
+    # **Step: produce the output
     produced_output = report.output(report.get_result(), OUTPUT_TYPE)
+    # **Step: display the output
     display.message(produced_output)
     # Section: Return control back to __main__ in gatorgrader
     # Only step: determine the correct exit code for the checks

--- a/gator/report.py
+++ b/gator/report.py
@@ -21,10 +21,10 @@ TEXT = "output_text"
 JSON = "output_json"
 
 
-def create_result(check, outcome, diagnostic):
+def create_result(description, outcome, diagnostic):
     """Create a new result dictionary."""
     result_dictionary = {}
-    result_dictionary[constants.results.Check] = check
+    result_dictionary[constants.results.Description] = description
     result_dictionary[constants.results.Outcome] = outcome
     result_dictionary[constants.results.Diagnostic] = diagnostic
     return result_dictionary
@@ -37,11 +37,11 @@ def reset():
     result = None
 
 
-def set_result(check, outcome, diagnostic):
+def set_result(description, outcome, diagnostic):
     """Set the current result dictionary."""
     # pylint: disable=global-statement
     global result
-    result = create_result(check, outcome, diagnostic)
+    result = create_result(description, outcome, diagnostic)
     return result
 
 
@@ -61,7 +61,7 @@ def output(dictionary_result, dictionary_format=TEXT):
 def output_text(dictionary_result) -> str:
     """Produce output in textual format."""
     # extract the details and form a string
-    check = dictionary_result[constants.results.Check]
+    description = dictionary_result[constants.results.Description]
     outcome = dictionary_result[constants.results.Outcome]
     diagnostic = dictionary_result[constants.results.Diagnostic]
     # there is a diagnostic, so include it on the next line
@@ -70,7 +70,7 @@ def output_text(dictionary_result) -> str:
             # display answer with a symbol not a boolean
             util.get_symbol_answer(outcome)
             + constants.markers.Space
-            + check
+            + description
             # SPACE
             + constants.markers.Space
             # NEWLINE
@@ -85,7 +85,9 @@ def output_text(dictionary_result) -> str:
         )
     # there is no diagnostic, so do not include anything else
     else:
-        submitted = util.get_symbol_answer(outcome) + constants.markers.Space + check
+        submitted = (
+            util.get_symbol_answer(outcome) + constants.markers.Space + description
+        )
     return submitted
 
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -47,6 +47,27 @@ def test_basic_check_correct():
         (["--json", "--nowelcome", "CheckCommits"]),
         (["--nowelcome", "CheckCommits"]),
         (["--checkerdir", "./gator/checks", "CheckCommits"]),
+        (["--description", "Are there 12 commits?", "CheckCommits"]),
+        (
+            [
+                "--checkerdir",
+                "./gator/checks",
+                "--description",
+                "Are there 18 commits?",
+                "CheckCommits",
+            ]
+        ),
+        (
+            [
+                "--json",
+                "--nowelcome",
+                "--checkerdir",
+                "./gator/checks",
+                "--description",
+                "Are there 18 commits?",
+                "CheckCommits",
+            ]
+        ),
     ],
 )
 def test_optional_commandline_arguments_can_verify(commandline_arguments):
@@ -75,6 +96,42 @@ def test_checkerdir_is_not_valid_arguments_verify(tmpdir):
     # this directory does not exist on the file system and verification should not work
     checker_directory = tmpdir.dirname + "/" + tmpdir.basename + "/" + "checksWRONG"
     commandline_arguments = ["--checkerdir", checker_directory, "check_FakeMessages"]
+    gg_arguments, remaining_arguments = arguments.parse(commandline_arguments)
+    args_verified = arguments.verify(gg_arguments)
+    assert args_verified is False
+
+
+def test_description_is_valid_arguments_verify():
+    """Check that command-line argument with valid string verifies."""
+    commandline_arguments = [
+        "--description",
+        "Do you have fake things?",
+        "check_FakeMessages",
+    ]
+    gg_arguments, remaining_arguments = arguments.parse(commandline_arguments)
+    args_verified = arguments.verify(gg_arguments)
+    assert args_verified is True
+
+
+def test_description_not_specified_is_not_valid_arguments_verify(capsys):
+    """Check that command-line argument without valid string verifies."""
+    commandline_arguments = ["--description", "--json", "check_FakeMessages"]
+    with pytest.raises(SystemExit):
+        gg_arguments, remaining_arguments = arguments.parse(commandline_arguments)
+        _ = arguments.verify(gg_arguments)
+    captured = capsys.readouterr()
+    assert "--description: expected one argument" in captured.err
+
+
+@pytest.mark.parametrize(
+    "commandline_arguments",
+    [
+        (["--description", "", "CheckCommits"]),
+        (["--description", 'Run the "check" check', "CheckCommits"]),
+    ],
+)
+def test_description_is_not_valid_arguments_verify(commandline_arguments):
+    """Check that command-line argument without valid string verifies."""
     gg_arguments, remaining_arguments = arguments.parse(commandline_arguments)
     args_verified = arguments.verify(gg_arguments)
     assert args_verified is False

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -20,7 +20,7 @@ def test_no_arguments_incorrect_system_exit(capsys):
     # standard error has two lines from pytest
     assert "usage:" in captured.err
     counted_newlines = captured.err.count("\n")
-    assert counted_newlines == 2
+    assert counted_newlines >= 2
 
 
 def test_no_arguments_incorrect_system_exit_not_verified(capsys):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -96,7 +96,7 @@ def test_packages_constant_defined():
 
 def test_results_constant_defined():
     """Check correctness for the variables in the results constant."""
-    assert constants.results.Check == "check"
+    assert constants.results.Description == "check"
     assert constants.results.Outcome == "outcome"
     assert constants.results.Diagnostic == "diagnostic"
 
@@ -315,7 +315,7 @@ def test_packages_constant_cannot_redefine():
 def test_results_constant_cannot_redefine():
     """Check cannot redefine the variables in the results constant."""
     with pytest.raises(AttributeError):
-        constants.results.Check = CANNOT_SET_CONSTANT_VARIABLE
+        constants.results.Description = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):
         constants.results.Outcome = CANNOT_SET_CONSTANT_VARIABLE
     with pytest.raises(AttributeError):

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,0 +1,75 @@
+"""Tests for the description module."""
+
+import pytest
+
+from gator import constants
+from gator import description
+
+
+class ArgParseWithDescription:
+    """Mock class for ArgParse object containing a description."""
+
+    def __init__(self, description):
+        """Initialize mocked object with the given description."""
+        self.description = description
+
+
+class ArgParseWithNoDescription:
+    """Mock class for ArgParse object not containing a description."""
+
+    def __init__(self):
+        """Initialize mocked object with a None description."""
+        # An actual argparse object returns 'None' for anything
+        # accessed via the "." operator that is not defined
+        self.description = None
+
+
+def test_get_description_argument_extracts_description():
+    """Check that the description extraction function extracts the correct description."""
+    desc = "A description"
+    argparse = ArgParseWithDescription(desc)
+    parsed_desc = description.get_description_argument(argparse)
+    assert parsed_desc == desc
+
+
+def test_get_description_argument_extracts_none():
+    """Check that the description extraction function extracts None."""
+    argparse = ArgParseWithNoDescription()
+    parsed_desc = description.get_description_argument(argparse)
+    assert parsed_desc is None
+
+
+def test_transform_result_dictionary_transforms_with_description():
+    """Check that the result transformation function adds the correct description."""
+    desc = "A description"
+    argparse = ArgParseWithDescription(desc)
+    result_dict = {constants.results.Description: "something else"}
+    result_dict = description.transform_result_dictionary(argparse, result_dict)
+    assert result_dict[constants.results.Description] == desc
+
+
+def test_transform_result_dictionary_transforms_with_no_description():
+    """Check that the result transformation function does not modify the result dictionary."""
+    argparse = ArgParseWithNoDescription()
+    dict_desc = "something else"
+    result_dict = {constants.results.Description: dict_desc}
+    result_dict = description.transform_result_dictionary(argparse, result_dict)
+    assert result_dict[constants.results.Description] == dict_desc
+
+
+@pytest.mark.parametrize(
+    "desc, expected_valid",
+    [
+        ("A description", True),
+        ("A description with 'single' quotes", True),
+        ("A description with 1 number.", True),
+        ("A description with 1/2+4-2*5 math.", True),
+        ("A description with @*&^%#1$?: symbols!", True),
+        ('A description with escaped "double" quotes', False),
+        ('A description with "double" quotes', False),
+    ],
+)
+def test_is_valid_description(desc, expected_valid):
+    """Check that the description validity function correctly detects if a description is valid."""
+    is_valid = description.is_valid_description(desc)
+    assert is_valid == expected_valid

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -51,7 +51,7 @@ def test_file_exists_in_directory_check(reset_results_dictionary, tmpdir):
     # file is found in the specified directory
     assert details is not None
     assert details[constants.results.Outcome] is True
-    assert "exists in" in details[constants.results.Check]
+    assert "exists in" in details[constants.results.Description]
     assert details[constants.results.Diagnostic] == ""
 
 
@@ -68,7 +68,7 @@ def test_file_exists_in_directory_check_test_file(reset_results_dictionary):
         # file is found in the specified directory
         assert details is not None
         assert details[constants.results.Outcome] is True
-        assert "exists in" in details[constants.results.Check]
+        assert "exists in" in details[constants.results.Description]
         assert details[constants.results.Diagnostic] == ""
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -15,7 +15,7 @@ def reset_results_dictionary():
 def test_create_result():
     """Create a result dictionary and check for the correct form."""
     new_result = report.create_result("Command executes", True, "")
-    assert new_result[constants.results.Check] == "Command executes"
+    assert new_result[constants.results.Description] == "Command executes"
     assert new_result[constants.results.Outcome] is True
     assert new_result[constants.results.Diagnostic] == ""
 
@@ -25,7 +25,7 @@ def test_create_result():
 def test_set_result(reset_results_dictionary):
     """Set the result dictionary and check if it keeps the values."""
     report.set_result("Command executes", True, "")
-    assert report.get_result()[constants.results.Check] == "Command executes"
+    assert report.get_result()[constants.results.Description] == "Command executes"
     assert report.get_result()[constants.results.Outcome] is True
     assert report.get_result()[constants.results.Diagnostic] == ""
 
@@ -35,7 +35,7 @@ def test_set_result(reset_results_dictionary):
 def test_set_result_return(reset_results_dictionary):
     """Set the result dictionary and check if it keeps the values."""
     new_result = report.set_result("Command executes", False, "Missing trailing slash")
-    assert new_result[constants.results.Check] == "Command executes"
+    assert new_result[constants.results.Description] == "Command executes"
     assert new_result[constants.results.Outcome] is False
     assert new_result[constants.results.Diagnostic] == "Missing trailing slash"
 
@@ -71,6 +71,6 @@ def test_output_json(reset_results_dictionary):
     assert "\n" not in output
     assert "Command executes" in output
     assert "true" in output
-    assert f'"{constants.results.Check}":' in output
+    assert f'"{constants.results.Description}":' in output
     assert f'"{constants.results.Outcome}":' in output
     assert f'"{constants.results.Diagnostic}":' in output


### PR DESCRIPTION
This PR implements the optional `--description <description>` argument, which uses the user-provided string to replace the auto-generated "check" description that is output to the user. This can be very useful, especially for checks with hard-to-understand default descriptions like regular expression checks, as the designer of the check can specify a plain-language description of what the check actually looks for.

### What is the current behavior?

Currently, all checks have an auto-generated description of what they check, e.g. `The main.py in primality/primality has exactly 0 of the 'TODO' fragment`.

### What is the new behavior if this PR is merged?

The check specification could include `--description "Remove all TODO lines in the primality/primality/main.py file"`, so that students would then see the following output from GatorGradle, for instance.

```text
✘  Remove all TODO lines in the primality/primality/main.py file
   ➔  Found 19 fragment(s) in the main.py or the output
```

This would make checks (and the reason they may be failing) easier to understand for students. The only character not allowed in these descriptions is the double quotes `"`, to maintain compatibility with the implementation of GatorGradle's shellword splitting algorithm.

#### Other information

Before merging this PR, basic tests should be completed with an example repository and GatorGradle, with the `version: feature/override-description` line set in the frontmatter of `config/gatorgrader.yml`. This should ensure end-to-end integration is correctly working, and that the `--description` argument will be available to all GatorGradle users once this is merged to master.

Commit messages in this PR are formatted to use the imperative mood, but do not fully conform to this repository's guidelines. If the maintainers wish these messages changed, I can do so.

##### This PR has:

- [ ] Commit messages that are correctly formatted
- [x] Tests for newly introduced code
- [x] Docstrings for newly introduced code

This PR is a feature update.

<!-- We required the above line statement because GatorGrader uses: -->
<!-- https://github.com/Michionlion/pr-tag-release -->
<!-- to automatically generate a tag and a release from a merged PR -->

#### Developers

@Michionlion 
