### PR TITLE
Add expected number of fragments to output

### DIFF
--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -534,13 +534,16 @@ def invoke_all_fragment_checks(
     )
     diagnostic = (
         "Found "
+        + ("only " if actual_count < expected_count else "")
         + str(actual_count)
         + constants.markers.Space
         + "fragment(s)"
         + constants.markers.Space
         + fragment_diagnostic
         + constants.markers.Space
-        + "or the output"
+        + "or the output while expecting "
+        + ("at least " if not exact else "")
+        + str(expected_count)
     )
     report_result(met_or_exceeded_count, message, diagnostic)
     return met_or_exceeded_count

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -542,7 +542,7 @@ def invoke_all_fragment_checks(
         + fragment_diagnostic
         + constants.markers.Space
         + "or the output while expecting "
-        + ("at least " if not exact else "")
+        + ("exactly " if exact else "at least ")
         + str(expected_count)
     )
     report_result(met_or_exceeded_count, message, diagnostic)

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -534,7 +534,6 @@ def invoke_all_fragment_checks(
     )
     diagnostic = (
         "Found "
-        + ("only " if actual_count < expected_count else "")
         + str(actual_count)
         + constants.markers.Space
         + "fragment(s)"


### PR DESCRIPTION
This PR adds the expected number of fragments in the diagnostic for failed fragment counts.

### What is the current behavior?

Currently, the output does not show how many fragments are expected, which is unhelpful to students trying to gauge their progress.

### What is the new behavior if this PR is merged?

With these changes, the diagnostic output shows how many fragments are expected.

#### Other information

##### This PR has:

- [x] Commit messages that are correctly formatted
- [ ] Tests for newly introduced code
- [ ] Docstrings for newly introduced code

This PR is a small change.

<!-- We required the above line statement because GatorGrader uses: -->
<!-- https://github.com/Michionlion/pr-tag-release -->
<!-- to automatically generate a tag and a release from a merged PR -->

#### Developers

@mariakimheinert
